### PR TITLE
fix(PE-4587): update fqdn check

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -140,7 +140,7 @@ export function calculateMinimumAuctionBid({
 
 // check if a string is a valid fully qualified domain name
 export function isValidFQDN(fqdn: string): boolean {
-  const fqdnRegex = /^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{1,6}$/;
+  const fqdnRegex = /^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{1,63}$/;
   return fqdnRegex.test(fqdn);
 }
 

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -391,6 +391,7 @@ describe('Network', () => {
         'trailing-',
         'bananas.one two three',
         'this-is-a-looong-name-a-verrrryyyyy-loooooong-name-that-is-too-long',
+        '192.168.1.1',
         12345,
       ])(
         'should not modify gateway settings with invalid fqdn',


### PR DESCRIPTION
Changes FQDN check to allow for up to 63 character TLDs when joining a gateway or changing settings.