### PR TITLE
chore(tests): add bail command so test failures are easier to diagnose

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:fix": "prettier . --write",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "yarn build && jest tests --runInBand",
+    "test": "yarn build && jest tests --runInBand --bail",
     "evolve": "yarn ts-node ./tools/evolve-contract.ts",
     "prepare": "husky install",
     "pre-commit": "lint-staged"


### PR DESCRIPTION
Our tests take a long time and tracing failures is difficult. Adding this flag will force mocha to exit on first test failure so they can be addressed one by one.