### PR TITLE
feat(auctions): make auction settings a top level settings object

### DIFF
--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -3,11 +3,7 @@ import {
   SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
 } from '../../constants';
 import { ContractResult, IOState, PstAction } from '../../types';
-import {
-  calculatePermabuyFee,
-  calculateTotalRegistrationFee,
-  getAuctionPrices,
-} from '../../utilities';
+import { calculateRegistrationFee, getAuctionPrices } from '../../utilities';
 
 declare const SmartWeave: any;
 
@@ -23,15 +19,13 @@ export const getAuction = (
   if (!auction) {
     const { floorPriceMultiplier, startPriceMultiplier } = auctionSettings;
 
-    const registrationFee =
-      type === 'lease'
-        ? calculateTotalRegistrationFee(
-            name,
-            fees,
-            1,
-            +SmartWeave.block.timestamp,
-          )
-        : calculatePermabuyFee(name, fees, +SmartWeave.block.timestamp);
+    const registrationFee = calculateRegistrationFee({
+      type,
+      name,
+      fees,
+      years: 1,
+      currentBlockTimestamp: +SmartWeave.block.timestamp,
+    });
 
     const floorPrice = registrationFee * floorPriceMultiplier;
     const startPrice = floorPrice * startPriceMultiplier;

--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -52,22 +52,29 @@ export const getAuction = (
       record.endTimestamp > +SmartWeave.block.timestamp;
 
     const reservedName = reserved[formattedName];
+
+    // TODO: move to util function
     const isActiveReservedName =
       reservedName &&
       reservedName.endTimestamp &&
       reservedName.endTimestamp > +SmartWeave.block.timestamp;
 
+    // TODO: move to util function
     const isShortNameRestricted =
       formattedName.length < MINIMUM_ALLOWED_NAME_LENGTH &&
       SmartWeave.block.timestamp < SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP;
 
+    // TODO: move to util function
     const isAvailableForAuction =
       !isExistingActiveRecord &&
       !isActiveReservedName &&
       !isShortNameRestricted;
 
+    // TODO: move to util function
     const isRequiredToBeAuctioned =
-      formattedName.length > MINIMUM_ALLOWED_NAME_LENGTH && formattedName < 12;
+      type == 'permabuy' &&
+      formattedName.length > MINIMUM_ALLOWED_NAME_LENGTH &&
+      formattedName < 12;
 
     return {
       result: {

--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -3,6 +3,7 @@ import {
   calculateRegistrationFee,
   getAuctionPrices,
   isNameAvailableForAuction,
+  isNameRequiredToBeAuction,
 } from '../../utilities';
 
 declare const SmartWeave: any;
@@ -45,7 +46,7 @@ export const getAuction = (
     // reserved name
     const reservedName = reserved[formattedName];
 
-    // TODO: move to util function
+    // check if name is available for auction
     const isAvailableForAuction = isNameAvailableForAuction({
       caller,
       name: formattedName,
@@ -54,9 +55,11 @@ export const getAuction = (
       currentBlockTimestamp,
     });
 
-    // TODO: move to util function
-    const isRequiredToBeAuctioned =
-      type == 'permabuy' && formattedName.length < 12;
+    // some names must be auctioned depending on the type
+    const isRequiredToBeAuctioned = isNameRequiredToBeAuction({
+      name: formattedName,
+      type,
+    });
 
     return {
       result: {

--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -72,19 +72,17 @@ export const getAuction = (
 
     // TODO: move to util function
     const isRequiredToBeAuctioned =
-      type == 'permabuy' &&
-      formattedName.length > MINIMUM_ALLOWED_NAME_LENGTH &&
-      formattedName < 12;
+      type == 'permabuy' && formattedName.length < 12;
 
     return {
       result: {
         name,
-        prices,
         isActive: false,
         isAvailableForAuction: isAvailableForAuction,
         isRequiredToBeAuctioned: isRequiredToBeAuctioned,
         minimumBid: floorPrice, // since its not active yet, the minimum bid is the floor price
         endHeight: +SmartWeave.block.height + auctionSettings.auctionDuration,
+        prices,
         settings: auctionSettings,
       },
     };

--- a/src/actions/write/buyRecord.ts
+++ b/src/actions/write/buyRecord.ts
@@ -1,5 +1,6 @@
 import {
   ARNS_NAME_IN_AUCTION_MESSAGE,
+  ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE,
   ARNS_NAME_RESERVED_MESSAGE,
   DEFAULT_UNDERNAME_COUNT,
   INVALID_SHORT_NAME,
@@ -9,12 +10,18 @@ import {
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
 } from '../../constants';
-import { ContractResult, IOState, PstAction } from '../../types';
+import {
+  ContractResult,
+  IOState,
+  PstAction,
+  RegistrationType,
+} from '../../types';
 import {
   calculateRegistrationFee,
   getInvalidAjvMessage,
   isActiveReservedName,
   isExistingActiveRecord,
+  isNameRequiredToBeAuction,
   isShortNameRestricted,
   walletHasSufficientBalance,
 } from '../../utilities';
@@ -29,7 +36,7 @@ export class BuyRecord {
   name: string;
   contractTxId: string;
   years: number;
-  type: 'lease' | 'permabuy';
+  type: RegistrationType;
   auction: boolean;
   qty: number;
 
@@ -112,6 +119,10 @@ export const buyRecord = (
     })
   ) {
     throw new ContractError(NON_EXPIRED_ARNS_NAME_MESSAGE);
+  }
+
+  if (isNameRequiredToBeAuction({ name, type })) {
+    throw new ContractError(ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE);
   }
 
   // set the end lease period for this based on number of years if it's a lease

--- a/src/actions/write/buyRecord.ts
+++ b/src/actions/write/buyRecord.ts
@@ -14,8 +14,7 @@ import {
 } from '../../constants';
 import { ContractResult, IOState, PstAction } from '../../types';
 import {
-  calculatePermabuyFee,
-  calculateTotalRegistrationFee,
+  calculateRegistrationFee,
   getInvalidAjvMessage,
   walletHasSufficientBalance,
 } from '../../utilities';
@@ -138,16 +137,13 @@ export const buyRecord = (
     type === 'lease' ? currentBlockTime + SECONDS_IN_A_YEAR * years : undefined;
 
   // TODO: add dynamic pricing
-  // calculate the total fee (initial registration + annual)
-  const totalRegistrationFee =
-    type === 'lease'
-      ? calculateTotalRegistrationFee(
-          name,
-          fees,
-          years,
-          +SmartWeave.block.timestamp,
-        )
-      : calculatePermabuyFee(name, fees, +SmartWeave.block.timestamp);
+  const totalRegistrationFee = calculateRegistrationFee({
+    name,
+    fees,
+    years,
+    type,
+    currentBlockTimestamp: +SmartWeave.block.timestamp,
+  });
 
   if (!walletHasSufficientBalance(balances, caller, totalRegistrationFee)) {
     throw new ContractError(

--- a/src/actions/write/buyRecord.ts
+++ b/src/actions/write/buyRecord.ts
@@ -5,17 +5,17 @@ import {
   INVALID_SHORT_NAME,
   INVALID_YEARS_MESSAGE,
   MAX_YEARS,
-  MINIMUM_ALLOWED_NAME_LENGTH,
   NON_EXPIRED_ARNS_NAME_MESSAGE,
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
-  SECONDS_IN_GRACE_PERIOD,
-  SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
 } from '../../constants';
 import { ContractResult, IOState, PstAction } from '../../types';
 import {
   calculateRegistrationFee,
   getInvalidAjvMessage,
+  isActiveReservedName,
+  isExistingActiveRecord,
+  isShortNameRestricted,
   walletHasSufficientBalance,
 } from '../../utilities';
 // composed by ajv at build
@@ -61,9 +61,9 @@ export const buyRecord = (
   { caller, input }: PstAction,
 ): ContractResult => {
   // get all other relevant state data
-  const { balances, records, reserved, fees, auctions, owner } = state;
+  const { balances, records, reserved, fees, auctions } = state;
   const { name, contractTxId, years, type, auction } = new BuyRecord(input); // does validation on constructor
-  const currentBlockTime = +SmartWeave.block.timestamp;
+  const currentBlockTimestamp = +SmartWeave.block.timestamp;
 
   // auction logic if auction flag set
   if (auction) {
@@ -91,50 +91,34 @@ export const buyRecord = (
     throw new ContractError(INVALID_YEARS_MESSAGE);
   }
 
-  if (reserved[name]) {
-    const { target, endTimestamp: reservedEndTimestamp } = reserved[name];
+  if (
+    isActiveReservedName({
+      caller,
+      reservedName: reserved[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
+  }
 
-    /**
-     * Three scenarios:
-     *
-     * 1. name is reserved, regardless of length can be purchased only by target, unless expired
-     * 2. name is reserved, but only for a certain amount of time
-     * 3. name is reserved, with no target and no timestamp (i.e. target and timestamp are empty)
-     */
-    const handleReservedName = () => {
-      const reservedByCaller = target === caller;
-      const reservedExpired =
-        reservedEndTimestamp &&
-        reservedEndTimestamp <= +SmartWeave.block.timestamp;
-      if (!reservedByCaller && !reservedExpired) {
-        throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
-      }
+  if (isShortNameRestricted({ name, currentBlockTimestamp })) {
+    throw new ContractError(INVALID_SHORT_NAME);
+  }
 
-      delete reserved[name];
-      return;
-    };
-    handleReservedName();
-  } else {
-    // not reserved but it's a short name, it can only be auctioned after the short name auction expiration date has passed
-    const handleShortName = () => {
-      /**
-       * If a name is 1-4 characters, it can only be auctioned and after the set expiration.
-       */
-      if (
-        name.length < MINIMUM_ALLOWED_NAME_LENGTH &&
-        +SmartWeave.block.timestamp < SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP &&
-        !auction
-      ) {
-        throw new ContractError(INVALID_SHORT_NAME);
-      }
-      return;
-    };
-    handleShortName();
+  if (
+    isExistingActiveRecord({
+      record: records[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(NON_EXPIRED_ARNS_NAME_MESSAGE);
   }
 
   // set the end lease period for this based on number of years if it's a lease
   const endTimestamp =
-    type === 'lease' ? currentBlockTime + SECONDS_IN_A_YEAR * years : undefined;
+    type === 'lease'
+      ? currentBlockTimestamp + SECONDS_IN_A_YEAR * years
+      : undefined;
 
   // TODO: add dynamic pricing
   const totalRegistrationFee = calculateRegistrationFee({
@@ -151,22 +135,6 @@ export const buyRecord = (
     );
   }
 
-  // Check if the requested name exists on a lease and in a grace period
-  if (
-    records[name] &&
-    records[name].type === 'lease' &&
-    records[name].endTimestamp
-  ) {
-    const { endTimestamp } = records[name];
-    if (
-      endTimestamp &&
-      endTimestamp + SECONDS_IN_GRACE_PERIOD > +SmartWeave.block.timestamp
-    ) {
-      // name is still on active lease during grace period
-      throw new ContractError(NON_EXPIRED_ARNS_NAME_MESSAGE);
-    }
-  }
-
   // TODO: replace with protocol balance
   balances[caller] -= totalRegistrationFee;
   balances[SmartWeave.contract.id] += totalRegistrationFee;
@@ -179,6 +147,11 @@ export const buyRecord = (
     // only include timestamp on lease
     ...(type === 'lease' ? { endTimestamp } : {}),
   };
+
+  // delete the reserved name if it exists
+  if (reserved[name]) {
+    delete state.reserved[name];
+  }
 
   // update the records object
   state.records = records;

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -1,8 +1,7 @@
 import { NON_CONTRACT_OWNER_MESSAGE } from '../../constants';
 import { ContractResult, IOState, PstAction } from '../../types';
 
-declare const ContractError;
-declare const SmartWeave;
+declare const ContractError: any;
 
 // Updates this contract to new source code
 export const evolveState = async (
@@ -15,92 +14,14 @@ export const evolveState = async (
     throw new ContractError(NON_CONTRACT_OWNER_MESSAGE);
   }
 
-  // An amount to airdrop to gateway testnet operators
-  const airdrop = 1500;
-
-  // Set each gateway to have an empty array of vaults
-  for (const address in state.gateways) {
-    state.gateways[address].vaults = [];
-    if (address !== owner) {
-      state.balances[address] += airdrop; // Give each gateway operator an unlocked airdrop from owner wallet
-      state.balances[owner] -= airdrop; // Reduce amount from the owner wallet
-    }
-  }
-
   // Update Gateway Address Registry settings
-  state.settings.registry = {
-    minLockLength: 720, // 1 day of blocks
-    maxLockLength: 720 * 365 * 3, // 3 years of blocks
-    minNetworkJoinStakeAmount: 10000,
-    minGatewayJoinLength: 720 * 5, // The gateway may begin leave the network for 5 days of blocks
-    gatewayLeaveLength: 720 * 5, // The gateway must wait 5 days of blocks in order to fully leave the network
-    operatorStakeWithdrawLength: 720 * 5, // The gateway must wait 5 days of blocks to unlock and withdraw any stake
+  state.settings.auctions = {
+    floorPriceMultiplier: 1,
+    startPriceMultiplier: 50,
+    auctionDuration: 5040,
+    decayRate: 0.0225,
+    decayInterval: 30,
   };
-
-  // Update fees and 51 character names
-  state.fees = {
-    '1': 5_000_000,
-    '2': 500_000,
-    '3': 100_000,
-    '4': 25_000,
-    '5': 10_000,
-    '6': 5_000,
-    '7': 2_500,
-    '8': 1_500,
-    '9': 1_250,
-    '10': 1_250,
-    '11': 1_250,
-    '12': 1_250,
-    '13': 1_000, // this fee was missing previously
-    '14': 1_000,
-    '15': 1_000,
-    '16': 1_000,
-    '17': 1_000,
-    '18': 1_000,
-    '19': 1_000,
-    '20': 1_000,
-    '21': 1_000,
-    '22': 1_000,
-    '23': 1_000,
-    '24': 1_000,
-    '25': 1_000,
-    '26': 1_000,
-    '27': 1_000,
-    '28': 1_000,
-    '29': 1_000,
-    '30': 1_000,
-    '31': 1_000,
-    '32': 1_000,
-    '33': 1_000,
-    '34': 1_000,
-    '35': 1_000,
-    '36': 1_000,
-    '37': 1_000,
-    '38': 1_000,
-    '39': 1_000,
-    '40': 1_000,
-    '41': 1_000,
-    '42': 1_000,
-    '43': 1_000,
-    '44': 1_000,
-    '45': 1_000,
-    '46': 1_000,
-    '47': 1_000,
-    '48': 1_000,
-    '49': 1_000,
-    '50': 1_000,
-    '51': 1_000,
-  };
-
-  // Reclaim tokens from broken balance
-  const badBalance = 'T7179iMclGFeIztwWy02XOM-5Ebx10TINteE8K8N5Dk '; // Incorrect trailing space
-  if (state.balances[badBalance]) {
-    // If badBalance exists, add its value to owner's balance
-    state.balances[owner] += state.balances[badBalance];
-
-    // Delete the badBalance entry
-    delete state.balances[badBalance];
-  }
 
   return { state };
 };

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -12,6 +12,7 @@ import {
   ContractResult,
   IOState,
   PstAction,
+  RegistrationType,
 } from '../../types';
 import {
   calculateMinimumAuctionBid,
@@ -31,7 +32,7 @@ declare const SmartWeave: any;
 export class AuctionBid {
   name: string;
   qty?: number;
-  type: 'lease' | 'permabuy';
+  type: RegistrationType;
   contractTxId: string;
   years?: number;
   constructor(input: any) {

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -144,8 +144,7 @@ export const submitAuctionBid = (
   }
 
   // get the current auction settings, create one of it doesn't exist yet
-  const currentAuctionSettings: AuctionSettings =
-    settings.auctions.history.find((a) => a.id === settings.auctions.current)!;
+  const currentAuctionSettings: AuctionSettings = settings.auctions;
 
   // all the things we need to handle an auction bid
   const currentBlockHeight = +SmartWeave.block.height;
@@ -165,11 +164,8 @@ export const submitAuctionBid = (
 
   // no current auction, create one and vault the balance from the user
   if (!auctions[name]) {
-    const {
-      id: auctionSettingsId,
-      floorPriceMultiplier,
-      startPriceMultiplier,
-    } = currentAuctionSettings;
+    const { floorPriceMultiplier, startPriceMultiplier } =
+      currentAuctionSettings;
     // floor price multiplier could be a decimal, or whole number (e.g. 0.5 vs 2)
     const calculatedFloor = registrationFee * floorPriceMultiplier;
     // if someone submits a high floor price, we'll take it
@@ -186,7 +182,7 @@ export const submitAuctionBid = (
 
     // create the initial auction bid
     const initialAuctionBid = {
-      auctionSettingsId,
+      settings: currentAuctionSettings,
       floorPrice, // this is decremented from the initiators wallet, and could be higher than the precalculated floor
       startPrice,
       contractTxId,

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -18,8 +18,7 @@ import {
 } from '../../types';
 import {
   calculateMinimumAuctionBid,
-  calculatePermabuyFee,
-  calculateTotalRegistrationFee,
+  calculateRegistrationFee,
   getInvalidAjvMessage,
   walletHasSufficientBalance,
 } from '../../utilities';
@@ -151,16 +150,13 @@ export const submitAuctionBid = (
   const { decayInterval, decayRate, auctionDuration } = currentAuctionSettings;
 
   // TODO: add pricing demand factor
-  // calculate the standard registration fee
-  const registrationFee =
-    type === 'lease'
-      ? calculateTotalRegistrationFee(
-          name,
-          fees,
-          years!,
-          +SmartWeave.block.timestamp,
-        )
-      : calculatePermabuyFee(name, fees, +SmartWeave.block.timestamp);
+  const registrationFee = calculateRegistrationFee({
+    name,
+    fees,
+    years,
+    type,
+    currentBlockTimestamp: +SmartWeave.block.timestamp,
+  });
 
   // no current auction, create one and vault the balance from the user
   if (!auctions[name]) {

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -3,12 +3,9 @@ import {
   DEFAULT_UNDERNAME_COUNT,
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_SHORT_NAME,
-  MINIMUM_ALLOWED_NAME_LENGTH,
   NON_EXPIRED_ARNS_NAME_MESSAGE,
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
-  SECONDS_IN_GRACE_PERIOD,
-  SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
 } from '../../constants';
 import {
   AuctionSettings,
@@ -20,6 +17,9 @@ import {
   calculateMinimumAuctionBid,
   calculateRegistrationFee,
   getInvalidAjvMessage,
+  isActiveReservedName,
+  isExistingActiveRecord,
+  isShortNameRestricted,
   walletHasSufficientBalance,
 } from '../../utilities';
 // composed by ajv at build
@@ -69,77 +69,29 @@ export const submitAuctionBid = (
     years,
   } = new AuctionBid(input);
 
-  // name already exists on an active lease
-  if (records[name]) {
-    const { endTimestamp, type } = records[name];
+  const currentBlockTimestamp = +SmartWeave.block.timestamp;
 
-    /**
-     * Three scenarios:
-     *
-     * 1. The name is currently in records, but it's lease is expired - this means it can be removed from state
-     * 2. The name is currently in records, and not expired
-     * 3. The name is currently in records and is a permabuy
-     * @returns
-     */
-    const handleExistingName = () => {
-      if (
-        type === 'lease' &&
-        endTimestamp &&
-        endTimestamp + SECONDS_IN_GRACE_PERIOD <= +SmartWeave.block.timestamp
-      ) {
-        // lease has expired, remove from state and it's available for auction
-        delete records[name];
-        return;
-      }
-
-      // throw an error saying the name is already owned
-      throw new ContractError(NON_EXPIRED_ARNS_NAME_MESSAGE);
-    };
-
-    handleExistingName();
+  if (
+    isActiveReservedName({
+      caller,
+      reservedName: reserved[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
   }
 
-  if (reserved[name]) {
-    const { target, endTimestamp: reservedEndTimestamp } = reserved[name];
+  if (isShortNameRestricted({ name, currentBlockTimestamp })) {
+    throw new ContractError(INVALID_SHORT_NAME);
+  }
 
-    /**
-     * Three scenarios:
-     *
-     * 1. name is reserved, regardless of length can be purchased only by target, unless expired - the reserved name from state, making it available for anyone
-     * 2. name is reserved, but only for a certain amount of time
-     * 3. name is reserved, with no target and no timestamp (i.e. target and timestamp are empty)
-     */
-    const handleReservedName = () => {
-      const reservedByCaller = target === caller;
-      const reservedExpired =
-        reservedEndTimestamp &&
-        reservedEndTimestamp <= +SmartWeave.block.timestamp;
-      // the reservation has expired - delete from state and make it available for auctions/buying
-      if (!reservedByCaller && !reservedExpired) {
-        throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
-      }
-
-      // remove the reserved name from state and continue
-      delete reserved[name];
-      return;
-    };
-
-    handleReservedName();
-  } else {
-    // not reserved but it's a short name, it can only be auctioned after the short name auction expiration date has passed
-    const handleShortName = () => {
-      /**
-       * If a name is 1-4 characters, it can only be auctioned and after the set expiration.
-       */
-      if (
-        name.length < MINIMUM_ALLOWED_NAME_LENGTH &&
-        +SmartWeave.block.timestamp < SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP
-      ) {
-        throw new ContractError(INVALID_SHORT_NAME);
-      }
-      return;
-    };
-    handleShortName();
+  if (
+    isExistingActiveRecord({
+      record: records[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(NON_EXPIRED_ARNS_NAME_MESSAGE);
   }
 
   // get the current auction settings, create one of it doesn't exist yet
@@ -190,6 +142,11 @@ export const submitAuctionBid = (
     };
     auctions[name] = initialAuctionBid; // create the auction object
     balances[caller] -= floorPrice; // decremented based on the floor price
+
+    // delete the rename if exists
+    if (reserved[name]) {
+      delete reserved[name];
+    }
 
     // update the state
     state.auctions = auctions;

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -187,6 +187,7 @@ export const submitAuctionBid = (
       startPrice,
       contractTxId,
       startHeight: currentBlockHeight, // auction starts right away
+      endHeight: currentBlockHeight + auctionDuration, // auction ends after the set duration
       type,
       initiator: caller, // the balance that the floor price is decremented from
       ...(years ? { years } : {}),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,21 +97,10 @@ export const FEE_STRUCTURE = {
   '50': 50,
   '51': 50,
 };
-export const AUCTION_SETTINGS_ID =
-  '3IkWJ-0HdwuATDhBXuJRm0bWspXOOkRjxTm-5R2xRbw';
-export const AUCTION_SETTINGS: {
-  current: string;
-  history: AuctionSettings[];
-} = {
-  current: AUCTION_SETTINGS_ID,
-  history: [
-    {
-      id: AUCTION_SETTINGS_ID,
-      floorPriceMultiplier: 1,
-      startPriceMultiplier: 50,
-      decayInterval: 30, // decrement every 30 blocks - approx every 1 hour
-      decayRate: 0.0225, // 5% decay
-      auctionDuration: 5040, // approx 7 days long
-    },
-  ],
+export const AUCTION_SETTINGS: AuctionSettings = {
+  floorPriceMultiplier: 1,
+  startPriceMultiplier: 50,
+  decayInterval: 30, // decrement every 30 blocks - approx every 1 hour
+  decayRate: 0.0225, // 5% decay
+  auctionDuration: 5040, // approx 7 days long
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const MAX_ALLOWED_UNDERNAMES = 10_000; // when modifying these, update th
 export const UNDERNAME_REGISTRATION_IO_FEE = 1; // 1 IO token per undername
 export const NON_CONTRACT_OWNER_MESSAGE = `Caller is not the owner of the ArNS!`;
 export const INVALID_ARNS_NAME_MESSAGE = 'Invalid ArNS Record Name';
+export const ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE = 'Name must be auctioned.';
 export const ARNS_NAME_RESERVED_MESSAGE = 'Name is reserved.';
 export const ARNS_NAME_IN_AUCTION_MESSAGE = 'Name is currently in auction.';
 export const INVALID_INPUT_MESSAGE = 'Invalid input for interaction';

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type Auction = {
   startPrice: number;
   floorPrice: number;
   startHeight: number;
+  endHeight: number;
   type: 'lease' | 'permabuy';
   initiator: string;
   contractTxId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,12 +103,13 @@ export type GatewaySettings = {
 };
 
 export type AllowedProtocols = 'http' | 'https';
+export type RegistrationType = 'lease' | 'permabuy';
 
 export type ArNSName = {
   contractTxId: string; // The ANT Contract used to manage this name
   startTimestamp: number; // At what unix time (seconds since epoch) the lease starts
   endTimestamp?: number; // At what unix time (seconds since epoch) the lease ends
-  type: 'lease' | 'permabuy';
+  type: RegistrationType;
   undernames: number;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,15 +45,14 @@ export type Auction = {
   startPrice: number;
   floorPrice: number;
   startHeight: number;
-  auctionSettingsId: string;
   type: 'lease' | 'permabuy';
   initiator: string;
   contractTxId: string;
   years?: number;
+  settings: AuctionSettings;
 };
 
 export type AuctionSettings = {
-  id: string;
   floorPriceMultiplier: number; // if we ever want to drop prices
   startPriceMultiplier: number;
   auctionDuration: number;
@@ -61,20 +60,19 @@ export type AuctionSettings = {
   decayInterval: number;
 };
 
+export type GatewayRegistrySettings = {
+  minLockLength: number; // the minimum amount of blocks tokens can be locked in a community vault
+  maxLockLength: number; // the maximum amount of blocks tokens can be locked in a community vault
+  minNetworkJoinStakeAmount: number; // the minimum amount of tokens needed to stake to join the ar.io network as a gateway
+  minGatewayJoinLength: number; // the minimum amount of blocks a gateway can be joined to the ar.io network
+  gatewayLeaveLength: number; // the amount of blocks that have to elapse before a gateway leaves the network
+  operatorStakeWithdrawLength: number; // the amount of blocks that have to elapse before a gateway operator's stake is returned
+};
+
 export type ContractSettings = {
   // these settings control the various capabilities in the contract
-  registry: {
-    minLockLength: number; // the minimum amount of blocks tokens can be locked in a community vault
-    maxLockLength: number; // the maximum amount of blocks tokens can be locked in a community vault
-    minNetworkJoinStakeAmount: number; // the minimum amount of tokens needed to stake to join the ar.io network as a gateway
-    minGatewayJoinLength: number; // the minimum amount of blocks a gateway can be joined to the ar.io network
-    gatewayLeaveLength: number; // the amount of blocks that have to elapse before a gateway leaves the network
-    operatorStakeWithdrawLength: number; // the amount of blocks that have to elapse before a gateway operator's stake is returned
-  };
-  auctions: {
-    current: string;
-    history: AuctionSettings[];
-  };
+  registry: GatewayRegistrySettings;
+  auctions: AuctionSettings;
 };
 
 const gatewayStatus = [

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -15,7 +15,7 @@ import { Fees } from './types';
 
 declare const ContractError: any;
 
-export function calculateTotalRegistrationFee(
+export function calculateLeaseFee(
   name: string,
   fees: Fees,
   years: number,
@@ -259,4 +259,25 @@ export function getAuctionPrices({
     prices[intervalHeight] = price;
   }
   return prices;
+}
+
+export function calculateRegistrationFee({
+  type,
+  name,
+  fees,
+  years,
+  currentBlockTimestamp,
+}: {
+  type: 'lease' | 'permabuy';
+  name: string;
+  fees: Fees;
+  years: number;
+  currentBlockTimestamp: number;
+}): number {
+  switch (type) {
+    case 'lease':
+      return calculateLeaseFee(name, fees, years, currentBlockTimestamp);
+    case 'permabuy':
+      return calculatePermabuyFee(name, fees, currentBlockTimestamp);
+  }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -12,7 +12,7 @@ import {
   SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
   UNDERNAME_REGISTRATION_IO_FEE,
 } from './constants';
-import { ArNSName, Fees, ReservedName } from './types';
+import { ArNSName, Fees, RegistrationType, ReservedName } from './types';
 
 declare const ContractError: any;
 
@@ -163,7 +163,7 @@ export function walletHasSufficientBalance(
 export function calculateProRatedUndernameCost(
   qty: number,
   currentTimestamp: number,
-  type: 'lease' | 'permabuy',
+  type: RegistrationType,
   endTimestamp?: number,
 ): number {
   const fullCost =
@@ -269,7 +269,7 @@ export function calculateRegistrationFee({
   years,
   currentBlockTimestamp,
 }: {
-  type: 'lease' | 'permabuy';
+  type: RegistrationType;
   name: string;
   fees: Fees;
   years: number;
@@ -349,4 +349,14 @@ export function isNameAvailableForAuction({
     !isActiveReservedName({ reservedName, caller, currentBlockTimestamp }) &&
     !isShortNameRestricted({ name, currentBlockTimestamp })
   );
+}
+
+export function isNameRequiredToBeAuction({
+  name,
+  type,
+}: {
+  name: string;
+  type: RegistrationType;
+}): boolean {
+  return type === 'permabuy' && name.length < 12;
 }

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -196,6 +196,9 @@ describe('Auctions', () => {
                   floorPrice: expect.any(Number),
                   startPrice: expect.any(Number),
                   type: 'lease',
+                  endHeight:
+                    (await getCurrentBlock(arweave)) +
+                    AUCTION_SETTINGS.auctionDuration,
                   startHeight: await getCurrentBlock(arweave),
                   initiator: nonContractOwnerAddress,
                   contractTxId: ANT_CONTRACT_IDS[0],
@@ -417,6 +420,9 @@ describe('Auctions', () => {
                 startPrice: expect.any(Number),
                 type: 'lease',
                 startHeight: await getCurrentBlock(arweave),
+                endHeight:
+                  (await getCurrentBlock(arweave)) +
+                  AUCTION_SETTINGS.auctionDuration,
                 initiator: nonContractOwnerAddress,
                 contractTxId: ANT_CONTRACT_IDS[0],
                 years: 1,
@@ -461,6 +467,9 @@ describe('Auctions', () => {
             startPrice: expect.any(Number),
             type: 'permabuy',
             startHeight: await getCurrentBlock(arweave),
+            endHeight:
+              (await getCurrentBlock(arweave)) +
+              AUCTION_SETTINGS.auctionDuration,
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
             settings: AUCTION_SETTINGS,
@@ -551,6 +560,9 @@ describe('Auctions', () => {
             startPrice: expect.any(Number),
             type: 'lease',
             startHeight: await getCurrentBlock(arweave),
+            endHeight:
+              (await getCurrentBlock(arweave)) +
+              AUCTION_SETTINGS.auctionDuration,
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
             years: 1,
@@ -568,7 +580,6 @@ describe('Auctions', () => {
         it.each([-10, -1, 10, 19, 20, 69])(
           `should expect the bid amount to not exceed the start price after %s blocks`,
           async (block) => {
-            // fast forward a few blocks, then construct winning bid
             const winningBidQty = calculateMinimumAuctionBid({
               startHeight: auctionObj.startHeight,
               startPrice: auctionObj.startPrice,

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -8,7 +8,7 @@ import {
   NON_EXPIRED_ARNS_NAME_MESSAGE,
   SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
 } from '../src/constants';
-import { Auction, AuctionSettings, IOState } from '../src/types';
+import { Auction, IOState } from '../src/types';
 import { ANT_CONTRACT_IDS } from './utils/constants';
 import {
   calculateMinimumAuctionBid,
@@ -196,11 +196,11 @@ describe('Auctions', () => {
                   floorPrice: expect.any(Number),
                   startPrice: expect.any(Number),
                   type: 'lease',
-                  auctionSettingsId: AUCTION_SETTINGS.current,
                   startHeight: await getCurrentBlock(arweave),
                   initiator: nonContractOwnerAddress,
                   contractTxId: ANT_CONTRACT_IDS[0],
                   years: 1,
+                  settings: AUCTION_SETTINGS,
                 }),
               );
               expect(balances[nonContractOwnerAddress]).toEqual(
@@ -247,16 +247,14 @@ describe('Auctions', () => {
 
               it('should update the records object when a winning bid comes in', async () => {
                 // fast forward a few blocks, then construct winning bid
-                const auctionSettings: AuctionSettings =
-                  AUCTION_SETTINGS.history[0];
                 await mineBlocks(arweave, 3504);
                 const winningBidQty = calculateMinimumAuctionBid({
                   startHeight: auctionObj.startHeight,
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
                   currentBlockHeight: await getCurrentBlock(arweave),
-                  decayInterval: auctionSettings.decayInterval,
-                  decayRate: auctionSettings.decayRate,
+                  decayInterval: AUCTION_SETTINGS.decayInterval,
+                  decayRate: AUCTION_SETTINGS.decayRate,
                 });
                 const auctionBid = {
                   name: 'apple',
@@ -418,11 +416,11 @@ describe('Auctions', () => {
                 floorPrice: expect.any(Number),
                 startPrice: expect.any(Number),
                 type: 'lease',
-                auctionSettingsId: AUCTION_SETTINGS.current,
                 startHeight: await getCurrentBlock(arweave),
                 initiator: nonContractOwnerAddress,
                 contractTxId: ANT_CONTRACT_IDS[0],
                 years: 1,
+                settings: AUCTION_SETTINGS,
               });
               expect(balances[nonContractOwnerAddress]).toEqual(
                 prevState.balances[nonContractOwnerAddress] -
@@ -462,10 +460,10 @@ describe('Auctions', () => {
             floorPrice: expect.any(Number),
             startPrice: expect.any(Number),
             type: 'permabuy',
-            auctionSettingsId: AUCTION_SETTINGS.current,
             startHeight: await getCurrentBlock(arweave),
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
+            settings: AUCTION_SETTINGS,
           });
           expect(balances[nonContractOwnerAddress]).toEqual(
             prevState.balances[nonContractOwnerAddress] -
@@ -478,15 +476,14 @@ describe('Auctions', () => {
 
         it('should update the records object when a winning bid comes in', async () => {
           // fast forward a few blocks, then construct winning bid
-          const auctionSettings: AuctionSettings = AUCTION_SETTINGS.history[0];
           await mineBlocks(arweave, 3504);
           const winningBidQty = calculateMinimumAuctionBid({
             startHeight: auctionObj.startHeight,
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            decayInterval: auctionSettings.decayInterval,
-            decayRate: auctionSettings.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
+            decayRate: AUCTION_SETTINGS.decayRate,
           });
           const auctionBid = {
             name: 'microsoft',
@@ -553,11 +550,11 @@ describe('Auctions', () => {
             floorPrice: expect.any(Number),
             startPrice: expect.any(Number),
             type: 'lease',
-            auctionSettingsId: AUCTION_SETTINGS.current,
             startHeight: await getCurrentBlock(arweave),
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
             years: 1,
+            settings: AUCTION_SETTINGS,
           });
           expect(balances[nonContractOwnerAddress]).toEqual(
             prevState.balances[nonContractOwnerAddress] -
@@ -572,16 +569,13 @@ describe('Auctions', () => {
           `should expect the bid amount to not exceed the start price after %s blocks`,
           async (block) => {
             // fast forward a few blocks, then construct winning bid
-            const auctionSettings: AuctionSettings =
-              AUCTION_SETTINGS.history[0];
-
             const winningBidQty = calculateMinimumAuctionBid({
               startHeight: auctionObj.startHeight,
               startPrice: auctionObj.startPrice,
               floorPrice: auctionObj.floorPrice,
               currentBlockHeight: auctionObj.startHeight + block,
-              decayInterval: auctionSettings.decayInterval,
-              decayRate: auctionSettings.decayRate,
+              decayInterval: AUCTION_SETTINGS.decayInterval,
+              decayRate: AUCTION_SETTINGS.decayRate,
             });
 
             expect(winningBidQty).toBeLessThanOrEqual(auctionObj.startPrice);
@@ -590,15 +584,14 @@ describe('Auctions', () => {
 
         it('should update the records when the caller is the initiator, and only withdraw the difference of the current bid to the original floor price that was already withdrawn from the initiator', async () => {
           // fast forward a few blocks, then construct winning bid
-          const auctionSettings: AuctionSettings = AUCTION_SETTINGS.history[0];
           await mineBlocks(arweave, 3504);
           const winningBidQty = calculateMinimumAuctionBid({
             startHeight: auctionObj.startHeight,
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            decayInterval: auctionSettings.decayInterval,
-            decayRate: auctionSettings.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
+            decayRate: AUCTION_SETTINGS.decayRate,
           });
           const auctionBid = {
             name: 'tesla',

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -1,3 +1,4 @@
+import { write } from 'fs';
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
@@ -430,12 +431,12 @@ describe('Records', () => {
 
     it('should not be able to buy reserved name when the caller is not the target of the reserved name', async () => {
       const nonNameOwner = getLocalWallet(2);
+      contract.connect(nonNameOwner);
       const namePurchase = {
         name: 'twitter',
         contractTxId: ANT_CONTRACT_IDS[0],
         years: 1,
       };
-      contract.connect(nonNameOwner);
       const writeInteraction = await contract.writeInteraction(
         {
           function: 'buyRecord',

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -13,7 +13,7 @@ import {
 } from './utils/constants';
 import {
   calculatePermabuyFee,
-  calculateTotalRegistrationFee,
+  calculateRegistrationFee,
   getLocalArNSContractId,
   getLocalWallet,
 } from './utils/helper';
@@ -91,12 +91,13 @@ describe('Records', () => {
       );
 
       const currentBlock = await arweave.blocks.getCurrent();
-      const expectedPurchasePrice = calculateTotalRegistrationFee(
-        namePurchase.name,
-        prevState.fees,
-        namePurchase.years,
-        currentBlock.timestamp,
-      );
+      const expectedPurchasePrice = calculateRegistrationFee({
+        name: namePurchase.name,
+        type: 'lease',
+        fees: prevState.fees,
+        years: namePurchase.years,
+        currentBlockTimestamp: currentBlock.timestamp,
+      });
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
@@ -138,12 +139,13 @@ describe('Records', () => {
       );
 
       const currentBlock = await arweave.blocks.getCurrent();
-      const expectedPurchasePrice = calculateTotalRegistrationFee(
-        namePurchase.name!,
-        prevState.fees,
-        1,
-        currentBlock.timestamp,
-      );
+      const expectedPurchasePrice = calculateRegistrationFee({
+        name: namePurchase.name!,
+        fees: prevState.fees,
+        years: 1,
+        type: 'lease',
+        currentBlockTimestamp: currentBlock.timestamp,
+      });
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();


### PR DESCRIPTION
This is a breaking change to the contract, and clients will need to update accordingly (most importantly the portal) to properly handle. It will require an evolveState to be run.

Summary of changes:
- make `settings.auctions` object and remove `settings.auctions.history[0]` and `settings.auctions.current` 
- updates `getAuction` function to facilitate reqs of the portal - we will likely continue to iterate on this
- breaks out some existing busineess logic into util functions - to avoid bloating this PR i'll add unit tests for these (and other functions) in a separate PR