### PR TITLE
feat(PE-4825) add observer wallets to gar

### DIFF
--- a/schemas/network.js
+++ b/schemas/network.js
@@ -12,9 +12,7 @@ const joinNetworkSchema = {
     },
     fqdn: {
       type: 'string',
-      pattern:
-        // prettier-ignore
-        '^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+(?!-)[A-Za-z0-9-]{1,63}(?<!-)$', // eslint-disable-line no-useless-escape
+      pattern: '^(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{1,63}$', // eslint-disable-line no-useless-escape
     },
     port: {
       type: 'number',
@@ -23,7 +21,7 @@ const joinNetworkSchema = {
     },
     protocol: {
       type: 'string',
-      pattern: 'http|https',
+      pattern: '^(http|https)$',
     },
     properties: {
       type: 'string',
@@ -36,6 +34,10 @@ const joinNetworkSchema = {
     label: {
       type: 'string',
       pattern: '^.{1,64}$', // 1-64 characters
+    },
+    observerWallet: {
+      type: 'string',
+      pattern: '^[a-zA-Z0-9_-]{43}$',
     },
   },
   required: [

--- a/schemas/network.js
+++ b/schemas/network.js
@@ -37,7 +37,7 @@ const joinNetworkSchema = {
     },
     observerWallet: {
       type: 'string',
-      pattern: '^[a-zA-Z0-9_-]{43}$',
+      pattern: '^(|[a-zA-Z0-9_-]{43})$',
     },
   },
   required: [

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -15,91 +15,9 @@ export const evolveState = async (
     throw new ContractError(NON_CONTRACT_OWNER_MESSAGE);
   }
 
-  // An amount to airdrop to gateway testnet operators
-  const airdrop = 1500;
-
   // Set each gateway to have an empty array of vaults
   for (const address in state.gateways) {
-    state.gateways[address].vaults = [];
-    if (address !== owner) {
-      state.balances[address] += airdrop; // Give each gateway operator an unlocked airdrop from owner wallet
-      state.balances[owner] -= airdrop; // Reduce amount from the owner wallet
-    }
-  }
-
-  // Update Gateway Address Registry settings
-  state.settings.registry = {
-    minLockLength: 720, // 1 day of blocks
-    maxLockLength: 720 * 365 * 3, // 3 years of blocks
-    minNetworkJoinStakeAmount: 10000,
-    minGatewayJoinLength: 720 * 5, // The gateway may begin leave the network for 5 days of blocks
-    gatewayLeaveLength: 720 * 5, // The gateway must wait 5 days of blocks in order to fully leave the network
-    operatorStakeWithdrawLength: 720 * 5, // The gateway must wait 5 days of blocks to unlock and withdraw any stake
-  };
-
-  // Update fees and 51 character names
-  state.fees = {
-    '1': 5_000_000,
-    '2': 500_000,
-    '3': 100_000,
-    '4': 25_000,
-    '5': 10_000,
-    '6': 5_000,
-    '7': 2_500,
-    '8': 1_500,
-    '9': 1_250,
-    '10': 1_250,
-    '11': 1_250,
-    '12': 1_250,
-    '13': 1_000, // this fee was missing previously
-    '14': 1_000,
-    '15': 1_000,
-    '16': 1_000,
-    '17': 1_000,
-    '18': 1_000,
-    '19': 1_000,
-    '20': 1_000,
-    '21': 1_000,
-    '22': 1_000,
-    '23': 1_000,
-    '24': 1_000,
-    '25': 1_000,
-    '26': 1_000,
-    '27': 1_000,
-    '28': 1_000,
-    '29': 1_000,
-    '30': 1_000,
-    '31': 1_000,
-    '32': 1_000,
-    '33': 1_000,
-    '34': 1_000,
-    '35': 1_000,
-    '36': 1_000,
-    '37': 1_000,
-    '38': 1_000,
-    '39': 1_000,
-    '40': 1_000,
-    '41': 1_000,
-    '42': 1_000,
-    '43': 1_000,
-    '44': 1_000,
-    '45': 1_000,
-    '46': 1_000,
-    '47': 1_000,
-    '48': 1_000,
-    '49': 1_000,
-    '50': 1_000,
-    '51': 1_000,
-  };
-
-  // Reclaim tokens from broken balance
-  const badBalance = 'T7179iMclGFeIztwWy02XOM-5Ebx10TINteE8K8N5Dk '; // Incorrect trailing space
-  if (state.balances[badBalance]) {
-    // If badBalance exists, add its value to owner's balance
-    state.balances[owner] += state.balances[badBalance];
-
-    // Delete the badBalance entry
-    delete state.balances[badBalance];
+    state.gateways[address].observerWallet = address;
   }
 
   return { state };

--- a/src/actions/write/joinNetwork.ts
+++ b/src/actions/write/joinNetwork.ts
@@ -17,6 +17,7 @@ export class JoinNetwork {
   properties: string;
   protocol: 'http' | 'https';
   port: number;
+  observerWallet: string;
 
   constructor(input: any) {
     // validate using ajv validator
@@ -24,7 +25,16 @@ export class JoinNetwork {
       throw new ContractError(getInvalidAjvMessage(validateJoinNetwork, input));
     }
 
-    const { qty, label, port, fqdn, note, protocol, properties } = input;
+    const {
+      qty,
+      label,
+      port,
+      fqdn,
+      note,
+      protocol,
+      properties,
+      observerWallet,
+    } = input;
     this.qty = qty;
     this.label = label;
     this.port = port;
@@ -32,6 +42,7 @@ export class JoinNetwork {
     this.properties = properties;
     this.fqdn = fqdn;
     this.note = note;
+    this.observerWallet = observerWallet;
   }
 }
 
@@ -43,7 +54,7 @@ export const joinNetwork = async (
   const { balances, gateways = {}, settings } = state;
   const { registry: registrySettings } = settings;
 
-  const { qty, ...gatewaySettings } = new JoinNetwork(input);
+  const { qty, observerWallet, ...gatewaySettings } = new JoinNetwork(input);
 
   if (
     !balances[caller] ||
@@ -72,6 +83,7 @@ export const joinNetwork = async (
   state.balances[caller] -= qty;
   state.gateways[caller] = {
     operatorStake: qty,
+    observerWallet: observerWallet || caller, // if no observer wallet is provided, we add the caller by default
     vaults: [],
     settings: {
       ...gatewaySettings,

--- a/src/actions/write/updateGatewaySettings.ts
+++ b/src/actions/write/updateGatewaySettings.ts
@@ -18,8 +18,16 @@ export const updateGatewaySettings = async (
   const { gateways = {} } = state;
 
   // TODO: add object parsing validation
-  const { label, fqdn, port, protocol, properties, note, status } =
-    input as any;
+  const {
+    label,
+    fqdn,
+    port,
+    protocol,
+    properties,
+    note,
+    status,
+    observerWallet,
+  } = input as any;
 
   // TODO: consistent checks
   if (!(caller in gateways)) {
@@ -93,6 +101,16 @@ export const updateGatewaySettings = async (
       );
     } else {
       gateways[caller].status = status;
+    }
+  }
+
+  if (observerWallet) {
+    if (!isValidArweaveBase64URL(observerWallet)) {
+      throw new ContractError(
+        'Invalid observer wallet address.  Must be a valid Arweave Wallet Address.',
+      );
+    } else {
+      gateways[caller].observerWallet = observerWallet;
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export type GatewayStatus = (typeof gatewayStatus)[number];
 
 export type Gateway = {
   operatorStake: number; // the total stake of this gateway's operator.
+  observerWallet: string; // the wallet address used to save observation reports
   start: number; // At what block the gateway joined the network.
   end: number; // At what block the gateway can leave the network.  0 means no end date.
   status: GatewayStatus; // hidden represents not leaving, but not participating

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -17,6 +17,8 @@ import {
 import { arweave, warp } from './utils/services';
 
 describe('Network', () => {
+  let nonGatewayOperator: JWKInterface;
+  let nonGatewayOperatorAddress: string;
   let contract: Contract<PstState>;
   let owner: JWKInterface;
   let ownerAddress: string;
@@ -40,48 +42,36 @@ describe('Network', () => {
     });
 
     describe('join network', () => {
-      it('should join the network with correct parameters', async () => {
-        const { cachedValue: prevCachedValue } = await contract.readState();
-        const prevBalance =
-          prevCachedValue.state.balances[newGatewayOperatorAddress];
-        const joinGatewayPayload = {
-          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount + 1, // must meet the minimum
-          label: 'Test Gateway', // friendly label
-          fqdn: 'jest.io',
-          port: 3000,
-          protocol: 'http',
-          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
-          note: 'Our gateway is the best test gateway. Contact bob@ar.io for more.',
-        };
-        const writeInteraction = await contract.writeInteraction({
-          function: 'joinNetwork',
-          ...joinGatewayPayload,
-        });
-        expect(writeInteraction?.originalTxId).not.toBe(undefined);
-        const { cachedValue: newCachedValue } = await contract.readState();
-        const newState = newCachedValue.state as IOState;
-        expect(Object.keys(newCachedValue.errorMessages)).not.toContain(
-          writeInteraction!.originalTxId,
-        );
-        expect(newState.balances[newGatewayOperatorAddress]).toEqual(
-          prevBalance - joinGatewayPayload.qty,
-        );
-        expect(newState.gateways[newGatewayOperatorAddress]).toEqual({
-          operatorStake: joinGatewayPayload.qty,
-          status: NETWORK_JOIN_STATUS,
-          start: await getCurrentBlock(arweave),
-          end: 0,
-          vaults: [],
-          settings: {
-            label: joinGatewayPayload.label,
-            fqdn: joinGatewayPayload.fqdn,
-            port: joinGatewayPayload.port,
-            protocol: joinGatewayPayload.protocol,
-            properties: joinGatewayPayload.properties,
-            note: joinGatewayPayload.note,
-          },
-        });
-      });
+      it.each([
+        'blah',
+        500,
+        '%dZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g',
+        'NdZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g-NdZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g',
+      ])(
+        'should fail network join with invalid observer wallet address',
+        async (badObserverWallet) => {
+          const { cachedValue: prevCachedValue } = await contract.readState();
+          const joinGatewayPayload = {
+            observerWallet: badObserverWallet,
+            qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+            label: 'Test Gateway', // friendly label
+            fqdn: 'jest.io',
+            port: '443',
+            protocol: 'https',
+            properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+            note: 'Our gateway is the best test gateway. Contact bob@ar.io for more.',
+          };
+          const writeInteraction = await contract.writeInteraction({
+            function: 'joinNetwork',
+            ...joinGatewayPayload,
+          });
+          const { cachedValue: newCachedValue } = await contract.readState();
+          expect(Object.keys(newCachedValue.errorMessages)).toContain(
+            writeInteraction!.originalTxId,
+          );
+          expect(newCachedValue.state).toEqual(prevCachedValue.state);
+        },
+      );
 
       it.each(['', undefined, -1, 100_000])(
         'should fail for invalid ports',
@@ -158,105 +148,167 @@ describe('Network', () => {
         },
       );
 
-      it.each(['https://full-domain.net', undefined, 'abcde', 100])(
-        'should fail for invalid fqdn',
-        async (badFqdn) => {
-          const { cachedValue: prevCachedValue } = await contract.readState();
-          const joinGatewayPayload = {
-            qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
-            label: 'test gateway', // friendly label
-            fqdn: badFqdn,
-            port: 3000,
-            protocol: 'http',
-            properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
-            note: 'The best test gateway',
-          };
-          const writeInteraction = await contract.writeInteraction({
-            function: 'joinNetwork',
-            ...joinGatewayPayload,
-          });
-          const { cachedValue: newCachedValue } = await contract.readState();
-          expect(Object.keys(newCachedValue.errorMessages)).toContain(
-            writeInteraction!.originalTxId,
-          );
-          expect(newCachedValue.state).toEqual(prevCachedValue.state);
-        },
-      );
+      it.each([
+        'https://full-domain.net',
+        undefined,
+        'abcde',
+        'test domain.com',
+        'jons.cool.site.',
+        'a-very-really-long-domain-name-that-is-longer-than-63-characters.com',
+        'website.a-very-really-long-top-level-domain-name-that-is-longer-than-63-characters',
+        '-startingdash.com',
+        'trailingdash-.com',
+        '---.com',
+        ' ',
+        100,
+        '%percent.com',
+      ])('should fail for invalid fqdn', async (badFqdn) => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const joinGatewayPayload = {
+          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+          label: 'test gateway', // friendly label
+          fqdn: badFqdn,
+          port: 3000,
+          protocol: 'http',
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+          note: 'The best test gateway',
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        const { cachedValue: newCachedValue } = await contract.readState();
+        expect(Object.keys(newCachedValue.errorMessages)).toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newCachedValue.state).toEqual(prevCachedValue.state);
+      });
 
-      it.each(['', undefined, 100])(
-        'should fail for invalid note',
-        async (badNote) => {
-          const { cachedValue: prevCachedValue } = await contract.readState();
-          const joinGatewayPayload = {
-            qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
-            label: 'test gateway', // friendly label
-            fqdn: 'testnet.com',
-            port: 3000,
-            protocol: 'http',
-            properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
-            note: badNote,
-          };
-          const writeInteraction = await contract.writeInteraction({
-            function: 'joinNetwork',
-            ...joinGatewayPayload,
-          });
-          const { cachedValue: newCachedValue } = await contract.readState();
-          expect(Object.keys(newCachedValue.errorMessages)).toContain(
-            writeInteraction!.originalTxId,
-          );
-          expect(newCachedValue.state).toEqual(prevCachedValue.state);
-        },
-      );
+      it.each([
+        '',
+        undefined,
+        100,
+        'this note is way too long.  please ignore this very long note. this note is way too long.  please ignore this very long note. this note is way too long.  please ignore this very long note. this note is way too long.  please ignore this very long note. this note is way too long.  please ignore this very long note.',
+      ])('should fail for invalid note', async (badNote) => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const joinGatewayPayload = {
+          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+          label: 'test gateway', // friendly label
+          fqdn: 'testnet.com',
+          port: 3000,
+          protocol: 'http',
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+          note: badNote,
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        const { cachedValue: newCachedValue } = await contract.readState();
+        expect(Object.keys(newCachedValue.errorMessages)).toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newCachedValue.state).toEqual(prevCachedValue.state);
+      });
 
-      it.each(['', undefined, 100])(
-        'should fail for invalid properties',
-        async (badProperties) => {
-          const { cachedValue: prevCachedValue } = await contract.readState();
-          const joinGatewayPayload = {
-            qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
-            label: 'test gateway', // friendly label
-            fqdn: 'testnet.com',
-            port: 3000,
-            protocol: 'http',
-            properties: badProperties,
-            note: 'test note',
-          };
-          const writeInteraction = await contract.writeInteraction({
-            function: 'joinNetwork',
-            ...joinGatewayPayload,
-          });
-          const { cachedValue: newCachedValue } = await contract.readState();
-          expect(Object.keys(newCachedValue.errorMessages)).toContain(
-            writeInteraction!.originalTxId,
-          );
-          expect(newCachedValue.state).toEqual(prevCachedValue.state);
-        },
-      );
+      it.each([
+        '',
+        undefined,
+        100,
+        'not a tx',
+        'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY4*',
+      ])('should fail for invalid properties', async (badProperties) => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const joinGatewayPayload = {
+          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+          label: 'test gateway', // friendly label
+          fqdn: 'testnet.com',
+          port: 3000,
+          protocol: 'http',
+          properties: badProperties,
+          note: 'test note',
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        const { cachedValue: newCachedValue } = await contract.readState();
+        expect(Object.keys(newCachedValue.errorMessages)).toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newCachedValue.state).toEqual(prevCachedValue.state);
+      });
 
-      it.each([CONTRACT_SETTINGS.minNetworkJoinStakeAmount - 1])(
-        'should fail for invalid qty',
-        async (badQty) => {
-          const { cachedValue: prevCachedValue } = await contract.readState();
-          const joinGatewayPayload = {
-            qty: badQty, // must meet the minimum
-            label: 'test gateway', // friendly label
-            fqdn: 'testnet.com',
-            port: 3000,
-            protocol: 'http',
-            properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
-            note: 'test note',
-          };
-          const writeInteraction = await contract.writeInteraction({
-            function: 'joinNetwork',
-            ...joinGatewayPayload,
-          });
-          const { cachedValue: newCachedValue } = await contract.readState();
-          expect(Object.keys(newCachedValue.errorMessages)).toContain(
-            writeInteraction!.originalTxId,
-          );
-          expect(newCachedValue.state).toEqual(prevCachedValue.state);
-        },
-      );
+      it.each([
+        CONTRACT_SETTINGS.minNetworkJoinStakeAmount - 1,
+        100000000000000000000,
+        -1,
+        CONTRACT_SETTINGS.minNetworkJoinStakeAmount.toString,
+      ])('should fail for invalid qty', async (badQty) => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const joinGatewayPayload = {
+          qty: badQty, // must meet the minimum
+          label: 'test gateway', // friendly label
+          fqdn: 'testnet.com',
+          port: 3000,
+          protocol: 'http',
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+          note: 'test note',
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        const { cachedValue: newCachedValue } = await contract.readState();
+        expect(Object.keys(newCachedValue.errorMessages)).toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newCachedValue.state).toEqual(prevCachedValue.state);
+      });
+
+      it('should join the network with correct parameters', async () => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const prevBalance =
+          prevCachedValue.state.balances[newGatewayOperatorAddress];
+        const joinGatewayPayload = {
+          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+          label: 'Test Gateway', // friendly label
+          fqdn: 'jest.io',
+          port: 3000,
+          protocol: 'http',
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+          note: 'Our gateway is the best test gateway. Contact bob@ar.io for more.',
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        expect(writeInteraction?.originalTxId).not.toBe(undefined);
+        const { cachedValue: newCachedValue } = await contract.readState();
+        const newState = newCachedValue.state as IOState;
+        expect(Object.keys(newCachedValue.errorMessages)).not.toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newState.balances[newGatewayOperatorAddress]).toEqual(
+          prevBalance - joinGatewayPayload.qty,
+        );
+        expect(newState.gateways[newGatewayOperatorAddress]).toEqual({
+          operatorStake: joinGatewayPayload.qty,
+          status: NETWORK_JOIN_STATUS,
+          start: await getCurrentBlock(arweave),
+          end: 0,
+          observerWallet: newGatewayOperatorAddress,
+          vaults: [],
+          settings: {
+            label: joinGatewayPayload.label,
+            fqdn: joinGatewayPayload.fqdn,
+            port: joinGatewayPayload.port,
+            protocol: joinGatewayPayload.protocol,
+            properties: joinGatewayPayload.properties,
+            note: joinGatewayPayload.note,
+          },
+        });
+      });
     });
 
     describe('operator stake', () => {
@@ -398,6 +450,7 @@ describe('Network', () => {
 
     describe('gateway settings', () => {
       it('should modify gateway settings with correct parameters', async () => {
+        const observerWallet = 'iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA';
         const updatedGatewaySettings = {
           label: 'Updated Label', // friendly label
           port: 80,
@@ -408,6 +461,7 @@ describe('Network', () => {
         };
         const writeInteraction = await contract.writeInteraction({
           function: 'updateGatewaySettings',
+          observerWallet,
           ...updatedGatewaySettings,
         });
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -419,6 +473,9 @@ describe('Network', () => {
         expect(newState.gateways[newGatewayOperatorAddress].settings).toEqual(
           updatedGatewaySettings,
         );
+        expect(
+          newState.gateways[newGatewayOperatorAddress].observerWallet,
+        ).toEqual(observerWallet);
       });
 
       it('should modify gateway settings with correct status', async () => {
@@ -451,6 +508,28 @@ describe('Network', () => {
         );
         expect(newCachedValue.state).toEqual(prevCachedValue.state);
       });
+
+      it.each([
+        'blah',
+        500,
+        '%dZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g',
+        'NdZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g-NdZ3YRwMB2AMwwFYjKn1g88Y9nRybTo0qhS1ORq_E7g',
+      ])(
+        'should not modify gateway settings with incorrect observer wallet address',
+        async (badObserverWallet) => {
+          const { cachedValue: prevCachedValue } = await contract.readState();
+          const writeInteraction = await contract.writeInteraction({
+            function: 'updateGatewaySettings',
+            observerWallet: badObserverWallet,
+          });
+          expect(writeInteraction?.originalTxId).not.toBe(undefined);
+          const { cachedValue: newCachedValue } = await contract.readState();
+          expect(Object.keys(newCachedValue.errorMessages)).toContain(
+            writeInteraction!.originalTxId,
+          );
+          expect(newCachedValue.state).toEqual(prevCachedValue.state);
+        },
+      );
 
       it.each([
         'SUUUUUUUUUUUUUUUUUUUUUUUUUUPER LONG LABEL LONGER THAN 64 CHARS!!!!!!!!!',
@@ -664,9 +743,6 @@ describe('Network', () => {
   });
 
   describe('non-valid gateway operator', () => {
-    let nonGatewayOperator: JWKInterface;
-    let nonGatewayOperatorAddress: string;
-
     beforeAll(async () => {
       owner = getLocalWallet(0);
       ownerAddress = await arweave.wallets.getAddress(owner);

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -123,32 +123,41 @@ describe('Network', () => {
         },
       );
 
-      it.each(['', undefined, 1])(
-        'should fail for invalid label',
-        async (badLabel) => {
-          const { cachedValue: prevCachedValue } = await contract.readState();
-          const joinGatewayPayload = {
-            qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
-            label: badLabel, // friendly label
-            fqdn: 'jest.io',
-            port: 3000,
-            protocol: 'http',
-            properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
-            note: 'The best test gateway',
-          };
-          const writeInteraction = await contract.writeInteraction({
-            function: 'joinNetwork',
-            ...joinGatewayPayload,
-          });
-          const { cachedValue: newCachedValue } = await contract.readState();
-          expect(Object.keys(newCachedValue.errorMessages)).toContain(
-            writeInteraction!.originalTxId,
-          );
-          expect(newCachedValue.state).toEqual(prevCachedValue.state);
-        },
-      );
+      it.each([
+        '',
+        undefined,
+        1,
+        'SUUUUUUUUUUUUUUUUUUUUUUUUUUPER LONG LABEL LONGER THAN 64 CHARS!!!!!!!!!',
+      ])('should fail for invalid label', async (badLabel) => {
+        const { cachedValue: prevCachedValue } = await contract.readState();
+        const joinGatewayPayload = {
+          qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
+          label: badLabel, // friendly label
+          fqdn: 'jest.io',
+          port: 3000,
+          protocol: 'http',
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+          note: 'The best test gateway',
+        };
+        const writeInteraction = await contract.writeInteraction({
+          function: 'joinNetwork',
+          ...joinGatewayPayload,
+        });
+        const { cachedValue: newCachedValue } = await contract.readState();
+        expect(Object.keys(newCachedValue.errorMessages)).toContain(
+          writeInteraction!.originalTxId,
+        );
+        expect(newCachedValue.state).toEqual(prevCachedValue.state);
+      });
 
       it.each([
+        '',
+        '*&*##$%#',
+        '-leading',
+        'trailing-',
+        'bananas.one two three',
+        'this-is-a-looong-name-a-verrrryyyyy-loooooong-name-that-is-too-long',
+        '192.168.1.1',
         'https://full-domain.net',
         undefined,
         'abcde',
@@ -271,6 +280,7 @@ describe('Network', () => {
         const prevBalance =
           prevCachedValue.state.balances[newGatewayOperatorAddress];
         const joinGatewayPayload = {
+          observerWallet: '',
           qty: CONTRACT_SETTINGS.minNetworkJoinStakeAmount, // must meet the minimum
           label: 'Test Gateway', // friendly label
           fqdn: 'jest.io',
@@ -532,9 +542,9 @@ describe('Network', () => {
       );
 
       it.each([
-        'SUUUUUUUUUUUUUUUUUUUUUUUUUUPER LONG LABEL LONGER THAN 64 CHARS!!!!!!!!!',
-        0,
         '',
+        1,
+        'SUUUUUUUUUUUUUUUUUUUUUUUUUUPER LONG LABEL LONGER THAN 64 CHARS!!!!!!!!!',
       ])(
         'should not modify gateway settings with invalid label',
         async (badLabel) => {
@@ -587,7 +597,19 @@ describe('Network', () => {
         'bananas.one two three',
         'this-is-a-looong-name-a-verrrryyyyy-loooooong-name-that-is-too-long',
         '192.168.1.1',
-        12345,
+        'https://full-domain.net',
+        undefined,
+        'abcde',
+        'test domain.com',
+        'jons.cool.site.',
+        'a-very-really-long-domain-name-that-is-longer-than-63-characters.com',
+        'website.a-very-really-long-top-level-domain-name-that-is-longer-than-63-characters',
+        '-startingdash.com',
+        'trailingdash-.com',
+        '---.com',
+        ' ',
+        100,
+        '%percent.com',
       ])(
         'should not modify gateway settings with invalid fqdn',
         async (badFQDN) => {

--- a/tools/join-network.ts
+++ b/tools/join-network.ts
@@ -17,6 +17,14 @@ import { arweave, getContractManifest, initialize, warp } from './utilities';
   // simple setup script
   initialize();
 
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = JSON.parse(
+    process.env.JWK ? process.env.JWK : fs.readFileSync(keyfile).toString(),
+  );
+
+  // wallet address
+  const walletAddress = await arweave.wallets.getAddress(wallet);
+
   // the quantity of tokens to stake.  Must be greater than the minimum
   const qty = 100_000;
 
@@ -38,18 +46,13 @@ import { arweave, getContractManifest, initialize, warp } from './utilities';
   // an optional, short note to further describe this gateway and its status
   const note = 'Owned and operated by DTF.';
 
-  // Get the key file used for the distribution
-  const wallet: JWKInterface = JSON.parse(
-    process.env.JWK ? process.env.JWK : fs.readFileSync(keyfile).toString(),
-  );
+  // The observer wallet public address eg.iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA which is used to upload observation reports
+  const observerWallet = '';
 
   // gate the contract txId
   const arnsContractTxId =
     process.env.ARNS_CONTRACT_TX_ID ??
     'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
-
-  // wallet address
-  const walletAddress = await arweave.wallets.getAddress(wallet);
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({
@@ -66,6 +69,7 @@ import { arweave, getContractManifest, initialize, warp } from './utilities';
   const txId = await contract.writeInteraction(
     {
       function: 'joinNetwork',
+      observerWallet,
       qty,
       label,
       fqdn,

--- a/tools/update-gateway-settings.ts
+++ b/tools/update-gateway-settings.ts
@@ -29,6 +29,9 @@ import { arweave, getContractManifest, initialize, warp } from './utilities';
   // an optional, short note to further describe this gateway and its status
   // const note = 'Give me feedback about this gateway at my Xwitter @testgatewayguy'
 
+  // The observer wallet public address eg.iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA which is used to upload observation reports
+  // const observerWallet = '';
+
   // Get the key file used for the distribution
   const wallet: JWKInterface = JSON.parse(
     process.env.JWK ? process.env.JWK : fs.readFileSync(keyfile).toString(),
@@ -59,6 +62,7 @@ import { arweave, getContractManifest, initialize, warp } from './utilities';
       function: 'updateGatewaySettings',
       label,
       fqdn,
+      // observerWallet,
       // port,
       // protocol,
       // properties,


### PR DESCRIPTION
- all types are updated to include a new gateway observer wallet address.
- joinNetwork is updated so gateways can provide an additional arweave wallet for their observer
- updateGatewaySettings is updated so gateways can change their observer wallet
- dev tooling is updated to include observer wallet