### PR TITLE
feat(tick): tick state on every interaction

### DIFF
--- a/src/contract.ts
+++ b/src/contract.ts
@@ -36,7 +36,8 @@ export async function handle(
 ): Promise<ContractReadResult | ContractWriteResult> {
   const input = action.input;
 
-  // TODO: on any write interaction, tick state
+  // tick state on any interaction, even when reading, so users get the most recent evaluation
+  await tick(state);
 
   switch (input.function as IOContractFunctions) {
     case 'transfer':


### PR DESCRIPTION
As it stands, tick state should execute before writes, and also when evaluating reads. Ideally reads show the "ticked" state, and writes "tick" the state before doing any additional logic.