### PR TITLE
feat(pricing): add read API that gives the cost of certain interactions

### DIFF
--- a/schemas/auction.js
+++ b/schemas/auction.js
@@ -23,7 +23,7 @@ const auctionBidSchema = {
       pattern: '^(atomic|[a-zA-Z0-9-_]{43})$',
     },
   },
-  required: ['name', 'contractTxId'],
+  required: ['name'],
   additionalProperties: true,
 };
 

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -162,8 +162,9 @@ describe('getPriceForInteraction', () => {
       },
       expectedResult: number,
     ) => {
-      const fee = getPriceForInteraction(inputState, inputData);
-      expect(fee).toEqual(expectedResult);
+      const { result } = getPriceForInteraction(inputState, inputData);
+      expect((result as any).price).toEqual(expectedResult);
+      expect((result as any).input).toEqual(inputData.input);
     },
   );
 });

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -70,6 +70,87 @@ describe('getPriceForInteraction', () => {
       },
       1250,
     ],
+    [
+      'should return the correct price for increaseUndernameCount',
+      {
+        ...state,
+        records: {
+          'existing-record': {
+            contractTxId: 'test-contract-tx-id',
+            type: 'permabuy',
+            startTimestamp: +SmartWeave.block.timestamp,
+            undernames: 10,
+            purchasePrice: 1000,
+          },
+        },
+      } as IOState,
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'increaseUndernameCount',
+          name: 'existing-record',
+          qty: 5,
+        },
+      },
+      62500,
+    ],
+    [
+      'should return the current bid for an existing auction and submitAuctionBid',
+      {
+        ...state,
+        auctions: {
+          'existing-auction': {
+            startPrice: 1000,
+            floorPrice: 1,
+            startHeight: 0,
+            endHeight: 10,
+            initiator: 'initiator',
+            contractTxId: 'atomic',
+            type: 'lease',
+            years: 1,
+            settings: {
+              decayInterval: 1,
+              decayRate: 0.01,
+              auctionDuration: 10,
+              floorPriceMultiplier: 1,
+              startPriceMultiplier: 10,
+            },
+          },
+        },
+      } as IOState,
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'submitAuctionBid',
+          name: 'existing-auction',
+        },
+      },
+      990,
+    ],
+    [
+      'should return the floor price a new auction and submitAuctionBid',
+      {
+        ...state,
+        settings: {
+          ...state.settings,
+          auctions: {
+            decayInterval: 1,
+            decayRate: 0.01,
+            auctionDuration: 10,
+            floorPriceMultiplier: 1,
+            startPriceMultiplier: 10,
+          },
+        },
+      },
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'submitAuctionBid',
+          name: 'new-auction',
+        },
+      },
+      540000,
+    ],
   ])(
     '%s',
     (

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -27,9 +27,9 @@ describe('getPriceForInteraction', () => {
         records: {
           'existing-record': {
             contractTxId: 'test-contract-tx-id',
-            endTimestamp: Date.now() + SECONDS_IN_A_YEAR, // one years,
+            endTimestamp: +SmartWeave.block.timestamp + SECONDS_IN_A_YEAR, // one years,
             type: 'lease',
-            startTimestamp: Date.now(),
+            startTimestamp: +SmartWeave.block.timestamp,
             undernames: 10,
             purchasePrice: 1000,
           },

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -14,11 +14,11 @@ describe('getPriceForInteraction', () => {
         caller: 'test-caller',
         input: {
           function: 'buyRecord',
-          name: 'test',
+          name: 'test-buy-record',
           type: 'permabuy',
         },
       },
-      312500000,
+      500000,
     ],
     [
       'should return the correct price for extendRecord',

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -1,0 +1,88 @@
+import { SECONDS_IN_A_YEAR } from '../../constants';
+import { IOState } from '../../types';
+import { getBaselineState } from '../write/submitAuctionBid.test';
+import { getPriceForInteraction } from './price';
+
+describe('getPriceForInteraction', () => {
+  const state = getBaselineState();
+
+  it.each([
+    [
+      'should return the correct price for buyRecord',
+      state,
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'buyRecord',
+          name: 'test',
+          type: 'permabuy',
+        },
+      },
+      312500000,
+    ],
+    [
+      'should return the correct price for extendRecord',
+      {
+        ...state,
+        records: {
+          'existing-record': {
+            contractTxId: 'test-contract-tx-id',
+            endTimestamp: Date.now() + SECONDS_IN_A_YEAR, // one years,
+            type: 'lease',
+            startTimestamp: Date.now(),
+            undernames: 10,
+            purchasePrice: 1000,
+          },
+        },
+      } as IOState,
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'extendRecord',
+          name: 'existing-record',
+          years: 1,
+        },
+      },
+      50_000,
+    ],
+    [
+      'should return the correct price for increaseUndernameCount',
+      {
+        ...state,
+        records: {
+          'existing-record': {
+            contractTxId: 'test-contract-tx-id',
+            endTimestamp: +SmartWeave.block.timestamp + SECONDS_IN_A_YEAR, // one year from the current block timestamp,
+            type: 'lease',
+            startTimestamp: +SmartWeave.block.timestamp,
+            undernames: 10,
+            purchasePrice: 1000,
+          },
+        },
+      } as IOState,
+      {
+        caller: 'test-caller',
+        input: {
+          function: 'increaseUndernameCount',
+          name: 'existing-record',
+          qty: 5,
+        },
+      },
+      1250,
+    ],
+  ])(
+    '%s',
+    (
+      _: string,
+      inputState: IOState,
+      inputData: {
+        caller: string;
+        input: { function: string; [x: string]: unknown };
+      },
+      expectedResult: number,
+    ) => {
+      const fee = getPriceForInteraction(inputState, inputData);
+      expect(fee).toEqual(expectedResult);
+    },
+  );
+});

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -1,0 +1,173 @@
+import {
+  calculateMinimumAuctionBid,
+  createAuctionObject,
+} from '../../auctions';
+import {
+  MAX_ALLOWED_UNDERNAMES,
+  PERMABUY_LEASE_FEE_LENGTH,
+} from '../../constants';
+import {
+  calculateAnnualRenewalFee,
+  calculateRegistrationFee,
+  calculateUndernameCost,
+} from '../../pricing';
+import {
+  BlockHeight,
+  BlockTimestamp,
+  DeepReadonly,
+  IOState,
+} from '../../types';
+import {
+  assertAvailableRecord,
+  calculateYearsBetweenTimestamps,
+  isExistingActiveRecord,
+} from '../../utilities';
+import { BuyRecord } from '../write/buyRecord';
+import { ExtendRecord } from '../write/extendRecord';
+import { IncreaseUndernameCount } from '../write/increaseUndernameCount';
+import { AuctionBid } from '../write/submitAuctionBid';
+
+export type InteractionsWithFee =
+  | 'buyRecord'
+  | 'extendRecord'
+  | 'increaseUndernameCount'
+  | 'submitAuctionBid';
+
+export function getPriceForInteraction(
+  state: DeepReadonly<IOState>,
+  {
+    caller,
+    input,
+  }: { caller: string; input: { function: string; [x: string]: unknown } },
+): number {
+  // TODO: move all these to utility functions
+  switch (input.function as InteractionsWithFee) {
+    case 'buyRecord': {
+      const { name, years, type, auction } = new BuyRecord(input);
+      // TODO: move this to util so we can call it directly rather than recalling this function
+      if (auction) {
+        return getPriceForInteraction(state, {
+          caller,
+          input: {
+            ...input,
+            function: 'submitAuctionBid',
+          },
+        });
+      }
+      assertAvailableRecord({
+        caller,
+        name,
+        records: state.records,
+        reserved: state.reserved,
+        currentBlockTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+      });
+      const fee = calculateRegistrationFee({
+        name,
+        fees: state.fees,
+        type,
+        years,
+        currentBlockTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+        demandFactoring: state.demandFactoring,
+      });
+      return fee;
+    }
+    case 'submitAuctionBid': {
+      const { name } = new AuctionBid(input);
+      const auction = state.auctions[name];
+      assertAvailableRecord({
+        caller,
+        name,
+        records: state.records,
+        reserved: state.reserved,
+        currentBlockTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+      });
+      // we don't return minimum au
+      if (!auction) {
+        const newAuction = createAuctionObject({
+          name,
+          currentBlockTimestamp: new BlockTimestamp(
+            +SmartWeave.block.timestamp,
+          ),
+          currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
+          fees: state.fees,
+          auctionSettings: state.settings.auctions,
+          demandFactoring: state.demandFactoring,
+          type: 'lease',
+          initiator: caller,
+          contractTxId: SmartWeave.transaction.id,
+        });
+        return newAuction.floorPrice;
+      }
+      const fee = calculateMinimumAuctionBid({
+        startHeight: new BlockHeight(auction.startHeight),
+        currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
+        startPrice: auction.startPrice,
+        floorPrice: auction.floorPrice,
+        decayInterval: auction.settings.decayInterval,
+        decayRate: auction.settings.decayRate,
+      });
+      return fee.valueOf();
+    }
+    case 'extendRecord': {
+      const { name, years } = new ExtendRecord(input);
+      const record = state.records[name];
+      if (
+        !isExistingActiveRecord({
+          record,
+          currentBlockTimestamp: new BlockTimestamp(
+            +SmartWeave.block.timestamp,
+          ),
+        })
+      ) {
+        throw new ContractError(`Record ${name} does not exist.`);
+      }
+      if (record.type === 'permabuy') {
+        throw new ContractError('Cannot extend a permabuy record.');
+      }
+      const fee = calculateAnnualRenewalFee({ name, years, fees: state.fees });
+      return fee;
+    }
+    case 'increaseUndernameCount': {
+      const { name, qty } = new IncreaseUndernameCount(input);
+      const record = state.records[name];
+      if (
+        !isExistingActiveRecord({
+          record,
+          currentBlockTimestamp: new BlockTimestamp(
+            +SmartWeave.block.timestamp,
+          ),
+        })
+      ) {
+        throw new ContractError(
+          `Record is not active. Cannot increase undernames.`,
+        );
+      }
+      if (record.undernames + qty > MAX_ALLOWED_UNDERNAMES) {
+        throw new ContractError(
+          `Cannot purchase more than ${MAX_ALLOWED_UNDERNAMES} undernames. The current record has ${record.undernames}`,
+        );
+      }
+      const { endTimestamp, type } = record;
+      const yearsRemaining = endTimestamp
+        ? calculateYearsBetweenTimestamps({
+            startTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+            endTimestamp: new BlockTimestamp(endTimestamp),
+          })
+        : PERMABUY_LEASE_FEE_LENGTH;
+
+      const fee = calculateUndernameCost({
+        name,
+        fees: state.fees,
+        type,
+        years: yearsRemaining,
+        increaseQty: qty,
+        demandFactoring: state.demandFactoring,
+      });
+      return fee;
+    }
+    default:
+      throw new ContractError(
+        `Invalid function provided. Available options are 'buyRecord', 'extendRecord', and 'increaseUndernameCount'.`,
+      );
+  }
+}

--- a/src/actions/write/increaseUndernameCount.ts
+++ b/src/actions/write/increaseUndernameCount.ts
@@ -7,6 +7,7 @@ import {
 } from '../../constants';
 import { calculateUndernameCost } from '../../pricing';
 import {
+  ArNSNameData,
   BlockTimestamp,
   ContractWriteResult,
   IOState,
@@ -51,34 +52,22 @@ export const increaseUndernameCount = async (
   const record = records[name];
   const currentBlockTimestamp = new BlockTimestamp(+SmartWeave.block.timestamp);
 
-  // This name's lease has expired and cannot be extended
-  if (
-    !isExistingActiveRecord({
-      record,
-      currentBlockTimestamp,
-    })
-  ) {
-    if (!record) {
-      throw new ContractError(ARNS_NAME_DOES_NOT_EXIST_MESSAGE);
-    }
-    throw new ContractError(
-      `This name has expired and must renewed before its undername support can be extended.`,
-    );
-  }
+  // validate record can increase undernames
+  assertRecordCanIncreaseUndernameCount({
+    record,
+    qty,
+    currentBlockTimestamp,
+  });
 
-  const { undernames: existingUndernames = 10, type, endTimestamp } = record;
-  // the new total qty
-  const incrementedUndernames = existingUndernames + qty;
-  if (incrementedUndernames > MAX_ALLOWED_UNDERNAMES) {
-    throw new ContractError(MAX_UNDERNAME_MESSAGE);
-  }
-
+  const { endTimestamp, type, undernames: existingUndernames } = record;
   const yearsRemaining = endTimestamp
     ? calculateYearsBetweenTimestamps({
         startTimestamp: currentBlockTimestamp,
         endTimestamp: new BlockTimestamp(endTimestamp),
       })
     : PERMABUY_LEASE_FEE_LENGTH;
+
+  const incrementedUndernames = existingUndernames + qty;
 
   const additionalUndernameCost = calculateUndernameCost({
     name,
@@ -104,3 +93,33 @@ export const increaseUndernameCount = async (
 
   return { state };
 };
+
+export function assertRecordCanIncreaseUndernameCount({
+  record,
+  qty,
+  currentBlockTimestamp,
+}: {
+  record: ArNSNameData;
+  qty: number;
+  currentBlockTimestamp: BlockTimestamp;
+}): void {
+  // This name's lease has expired and cannot be extended
+  if (
+    !isExistingActiveRecord({
+      record,
+      currentBlockTimestamp,
+    })
+  ) {
+    if (!record) {
+      throw new ContractError(ARNS_NAME_DOES_NOT_EXIST_MESSAGE);
+    }
+    throw new ContractError(
+      `This name has expired and must renewed before its undername support can be extended.`,
+    );
+  }
+
+  // the new total qty
+  if (record.undernames + qty > MAX_ALLOWED_UNDERNAMES) {
+    throw new ContractError(MAX_UNDERNAME_MESSAGE);
+  }
+}

--- a/src/actions/write/increaseUndernameCount.ts
+++ b/src/actions/write/increaseUndernameCount.ts
@@ -3,6 +3,7 @@ import {
   INSUFFICIENT_FUNDS_MESSAGE,
   MAX_ALLOWED_UNDERNAMES,
   MAX_UNDERNAME_MESSAGE,
+  PERMABUY_LEASE_FEE_LENGTH,
 } from '../../constants';
 import { calculateUndernameCost } from '../../pricing';
 import {
@@ -72,10 +73,12 @@ export const increaseUndernameCount = async (
     throw new ContractError(MAX_UNDERNAME_MESSAGE);
   }
 
-  const yearsRemaining = calculateYearsBetweenTimestamps({
-    startTimestamp: currentBlockTimestamp,
-    endTimestamp: new BlockTimestamp(endTimestamp),
-  });
+  const yearsRemaining = endTimestamp
+    ? calculateYearsBetweenTimestamps({
+        startTimestamp: currentBlockTimestamp,
+        endTimestamp: new BlockTimestamp(endTimestamp),
+      })
+    : PERMABUY_LEASE_FEE_LENGTH;
 
   const additionalUndernameCost = calculateUndernameCost({
     name,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -12,6 +12,7 @@ import {
   prescribedObserver,
   prescribedObservers,
 } from './actions/read/observation';
+import { getPriceForInteraction } from './actions/read/price';
 import { getRecord } from './actions/read/record';
 import { buyRecord } from './actions/write/buyRecord';
 import { decreaseOperatorStake } from './actions/write/decreaseOperatorStake';
@@ -89,6 +90,8 @@ export async function handle(
       return getAuction(tickedState, action);
     case 'saveObservations':
       return saveObservations(tickedState, action);
+    case 'priceForInteraction':
+      return getPriceForInteraction(tickedState, action);
     case 'tick':
       return tick(tickedState);
     default:

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -276,7 +276,7 @@ export function calculateUndernameCost({
   increaseQty: number;
   type: RegistrationType;
   years: number;
-  demandFactoring: DemandFactoringData;
+  demandFactoring: DeepReadonly<DemandFactoringData>;
 }): number {
   const initialNameFee = fees[name.length.toString()];
   const getUndernameFeePercentage = () => {
@@ -289,6 +289,6 @@ export function calculateUndernameCost({
   };
   const undernamePercentageFee = getUndernameFeePercentage();
   const totalFeeForQtyAndYears =
-    initialNameFee * (1 + undernamePercentageFee) * increaseQty * years;
+    initialNameFee * undernamePercentageFee * increaseQty * years;
   return demandFactoring.demandFactor * totalFeeForQtyAndYears;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,9 @@ export type IOContractFunctions = ObservationFunctions &
 
 export type ContractWriteResult = { state: IOState };
 // TODO: make this a union type of all the possible return types
-export type ContractReadResult = { result: unknown };
+export type ContractReadResult = {
+  result: unknown;
+};
 
 export interface Equatable<T> {
   equals(other: T): boolean;


### PR DESCRIPTION
This endpoint can be used by the portal to check prices before submitting any interaction.

Example request/response:
```shell
curl https://dev.arns.app/v1/contract/3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI/read/priceForInteraction?function=extendRecord&name=dylan&years=2
````
Response:

```json
{
  "result": {
    "input": { "function": "extendRecord", "name": "dylan", "years": 1 },
    "price": 50000
  }
}
```
We can make `price` more descriptive to represent the unit it is measured in (IO vs. mIO). 

Alternatiavely, you could get it via warp directly

```js
const contract = warp.connect('3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI');
const { result } = await contract.viewState('priceForInteraction', {
    function: 'extendRecord',
    name: 'dylan',
    years: 2
});

const costToExtend = result.price;
```