### PR TITLE
feat(PE-5019): move to block based pricing for auctions

### DIFF
--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -79,7 +79,7 @@ export const getAuction = (
         isActive: false,
         isAvailableForAuction: isAvailableForAuction,
         isRequiredToBeAuctioned: isRequiredToBeAuctioned,
-        minimumBid: auctionObject.floorPrice, // since its not active yet, the minimum bid is the floor price
+        currentPrice: auctionObject.floorPrice, // since its not active yet, the minimum bid is the floor price
         ...auctionObject,
         prices,
       },
@@ -126,7 +126,7 @@ export const getAuction = (
       isActive: expirationHeight >= +SmartWeave.block.height,
       isAvailableForAuction: false,
       isRequiredToBeAuctioned: isRequiredToBeAuctioned,
-      minimumBid: minimumBid.valueOf(),
+      currentPrice: minimumBid.valueOf(),
       ...auction,
       prices,
     },

--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -1,7 +1,7 @@
 import {
   calculateMinimumAuctionBid,
   createAuctionObject,
-  getAuctionPrices,
+  getAuctionPricesForInterval,
 } from '../../auctions';
 import {
   BlockHeight,
@@ -44,11 +44,12 @@ export const getAuction = (
       initiator: undefined,
     });
 
-    const prices = getAuctionPrices({
+    const prices = getAuctionPricesForInterval({
       auctionSettings,
       startHeight: currentBlockHeight, // set it to the current block height
       startPrice: auctionObject.startPrice,
       floorPrice: auctionObject.floorPrice,
+      blocksPerInterval: 30, // TODO: this could be an input on the function
     });
 
     // existing record
@@ -99,11 +100,12 @@ export const getAuction = (
   });
 
   // get all the prices for the auction
-  const prices = getAuctionPrices({
+  const prices = getAuctionPricesForInterval({
     auctionSettings: existingAuctionSettings,
     startHeight: new BlockHeight(startHeight),
     startPrice, // TODO: use IO class class
     floorPrice,
+    blocksPerInterval: 30, // TODO: this could be an input on the function
   });
 
   // calculate the minimum bid
@@ -112,9 +114,11 @@ export const getAuction = (
     startPrice,
     floorPrice,
     currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
-    decayInterval: existingAuctionSettings.decayInterval,
-    decayRate: existingAuctionSettings.decayRate,
+    scalingExponent: existingAuctionSettings.scalingExponent,
+    exponentialDecayRate: existingAuctionSettings.exponentialDecayRate,
   });
+
+  // TODO: return stringified function used to compute the current price of the auction so clients can calculate prices per block heights themselves
 
   return {
     result: {

--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -1,5 +1,5 @@
 import {
-  calculateMinimumAuctionBid,
+  calculateAuctionPriceForBlock,
   createAuctionObject,
   getAuctionPricesForInterval,
 } from '../../auctions';
@@ -109,7 +109,7 @@ export const getAuction = (
   });
 
   // calculate the minimum bid
-  const minimumBid = calculateMinimumAuctionBid({
+  const minimumBid = calculateAuctionPriceForBlock({
     startHeight: new BlockHeight(startHeight),
     startPrice,
     floorPrice,

--- a/src/actions/read/get-auctions.test.ts
+++ b/src/actions/read/get-auctions.test.ts
@@ -1,0 +1,82 @@
+import { IOState } from 'src/types';
+
+import { baselineAuctionData, getBaselineState } from '../../tests/stubs';
+import { getAuction } from './auction';
+
+describe('getAuction', () => {
+  const stubbedBlockHeight = 50;
+
+  beforeAll(() => {
+    // stub a height in the middle of the auction
+    SmartWeave.block.height = stubbedBlockHeight;
+  });
+
+  afterAll(() => {
+    // reset the block height
+    SmartWeave.block.height = 1;
+  });
+
+  it.each([
+    [
+      'should return details and correct price for an existing auction',
+      {
+        ...getBaselineState(),
+        auctions: {
+          'existing-auction': baselineAuctionData,
+        },
+      },
+      {
+        isActive: true,
+        isAvailableForAuction: false,
+        isRequiredToBeAuctioned: false,
+        currentPrice: 605.069371,
+        name: 'existing-auction',
+        prices: {
+          [baselineAuctionData.startHeight]: baselineAuctionData.startPrice,
+          [baselineAuctionData.startHeight + 30]: 737.424127,
+          [baselineAuctionData.startHeight + 60]: 538.615114,
+          [baselineAuctionData.startHeight + 90]: 389.416118,
+        },
+        ...baselineAuctionData,
+      },
+    ],
+    [
+      'should return details and floor price for a new auction',
+      {
+        ...getBaselineState(),
+      },
+      {
+        isActive: false,
+        isAvailableForAuction: true,
+        isRequiredToBeAuctioned: false,
+        currentPrice: 540000,
+        name: 'new-auction',
+        prices: {
+          [50]: 54000000,
+          [80]: 39820902.852326,
+          [110]: 29085216.161125,
+          [140]: 21028470.378378,
+        },
+        years: 1,
+        type: 'lease',
+        startHeight: stubbedBlockHeight,
+        endHeight:
+          stubbedBlockHeight +
+          getBaselineState().settings.auctions.auctionDuration,
+        startPrice: 54000000,
+        floorPrice: 540000,
+        initiator: undefined,
+        contractTxId: undefined,
+        settings: getBaselineState().settings.auctions,
+      },
+    ],
+  ])(`%s`, (_: string, inputState: IOState, expectedReadResult: any) => {
+    const { result } = getAuction(inputState, {
+      caller: 'test-caller',
+      input: {
+        name: expectedReadResult.name,
+      },
+    });
+    expect(result).toEqual(expectedReadResult);
+  });
+});

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -1,6 +1,6 @@
 import { SECONDS_IN_A_YEAR } from '../../constants';
+import { getBaselineState } from '../../tests/stubs';
 import { IOState } from '../../types';
-import { getBaselineState } from '../write/submitAuctionBid.test';
 import { InteractionsWithFee, getPriceForInteraction } from './price';
 
 describe('getPriceForInteraction', () => {

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -109,8 +109,8 @@ describe('getPriceForInteraction', () => {
             type: 'lease',
             years: 1,
             settings: {
-              decayInterval: 1,
-              decayRate: 0.01,
+              scalingExponent: 10,
+              exponentialDecayRate: 0.01,
               auctionDuration: 10,
               floorPriceMultiplier: 1,
               startPriceMultiplier: 10,
@@ -125,7 +125,7 @@ describe('getPriceForInteraction', () => {
           name: 'existing-auction',
         },
       },
-      990,
+      904.382075,
     ],
     [
       'should return the floor price a new auction and submitAuctionBid',
@@ -134,8 +134,8 @@ describe('getPriceForInteraction', () => {
         settings: {
           ...state.settings,
           auctions: {
-            decayInterval: 1,
-            decayRate: 0.01,
+            scalingExponent: 10,
+            exponentialDecayRate: 0.01,
             auctionDuration: 10,
             floorPriceMultiplier: 1,
             startPriceMultiplier: 10,

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -1,5 +1,5 @@
 import {
-  calculateMinimumAuctionBid,
+  calculateAuctionPriceForBlock,
   createAuctionObject,
 } from '../../auctions';
 import { PERMABUY_LEASE_FEE_LENGTH } from '../../constants';
@@ -108,7 +108,7 @@ export function getPriceForInteraction(
         fee = newAuction.floorPrice;
         break;
       }
-      const minimumAuctionBid = calculateMinimumAuctionBid({
+      const minimumAuctionBid = calculateAuctionPriceForBlock({
         startHeight: new BlockHeight(auction.startHeight),
         currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
         startPrice: auction.startPrice,

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -113,8 +113,8 @@ export function getPriceForInteraction(
         currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
         startPrice: auction.startPrice,
         floorPrice: auction.floorPrice,
-        decayInterval: auction.settings.decayInterval,
-        decayRate: auction.settings.decayRate,
+        scalingExponent: auction.settings.scalingExponent,
+        exponentialDecayRate: auction.settings.exponentialDecayRate,
       });
       fee = minimumAuctionBid.valueOf();
       break;

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -20,7 +20,7 @@ export const evolveState = async (
   state.settings.auctions = AUCTION_SETTINGS;
 
   // update existing auctions to use the new settings
-  for (const auction in Object.keys(state.auctions)) {
+  for (const auction of Object.keys(state.auctions)) {
     state.auctions[auction] = {
       ...state.auctions[auction],
       settings: AUCTION_SETTINGS,

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -19,6 +19,14 @@ export const evolveState = async (
   // update the auction settings object
   state.settings.auctions = AUCTION_SETTINGS;
 
+  // update existing auctions to use the new settings
+  for (const auction in Object.keys(state.auctions)) {
+    state.auctions[auction] = {
+      ...state.auctions[auction],
+      settings: AUCTION_SETTINGS,
+    };
+  }
+
   // transfer the forked states balance to the new one and delete the old balance
   state.balances[+SmartWeave.contract.id] +=
     state.balances['3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI'];

--- a/src/actions/write/saveObservations.test.ts
+++ b/src/actions/write/saveObservations.test.ts
@@ -3,10 +3,10 @@ import {
   INVALID_INPUT_MESSAGE,
   NETWORK_LEAVING_STATUS,
 } from '../../constants';
+import { getBaselineState } from '../../tests/stubs';
 import { Gateway, IOState, Observations, WeightedObserver } from '../../types';
 import { getPrescribedObservers } from '../../utilities';
 import { saveObservations } from './saveObservations';
-import { getBaselineState } from './submitAuctionBid.test';
 
 jest.mock('../../utilities', () => ({
   ...jest.requireActual('../../utilities'),

--- a/src/actions/write/submitAuctionBid.test.ts
+++ b/src/actions/write/submitAuctionBid.test.ts
@@ -22,8 +22,8 @@ const baselineDemandFactorData: DemandFactoringData = {
 
 const baselineAuctionSettings = {
   auctionDuration: 100,
-  decayInterval: 10,
-  decayRate: 0.9,
+  scalingExponent: 10,
+  exponentialDecayRate: 0.001,
   startPriceMultiplier: 100,
   floorPriceMultiplier: 1,
 };

--- a/src/actions/write/submitAuctionBid.test.ts
+++ b/src/actions/write/submitAuctionBid.test.ts
@@ -6,83 +6,14 @@ import {
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
 } from '../../constants';
-import { FEE_STRUCTURE } from '../../constants';
-import { AuctionData, DemandFactoringData, IOState } from '../../types';
-
-const baselineDemandFactorData: DemandFactoringData = {
-  periodZeroBlockHeight: 0,
-  currentPeriod: 0,
-  trailingPeriodPurchases: [0, 0, 0, 0, 0, 0, 0],
-  trailingPeriodRevenues: [0, 0, 0, 0, 0, 0, 0],
-  purchasesThisPeriod: 0,
-  revenueThisPeriod: 0,
-  demandFactor: 1,
-  consecutivePeriodsWithMinDemandFactor: 0,
-};
-
-const baselineAuctionSettings = {
-  auctionDuration: 100,
-  scalingExponent: 10,
-  exponentialDecayRate: 0.001,
-  startPriceMultiplier: 100,
-  floorPriceMultiplier: 1,
-};
-
-export const getBaselineState = (): IOState => ({
-  ticker: 'ARNS-TEST',
-  name: 'Arweave Name System Test',
-  canEvolve: true,
-  owner: '',
-  evolve: '',
-  records: {},
-  balances: {},
-  reserved: {},
-  fees: {
-    ...FEE_STRUCTURE,
-  },
-  auctions: {},
-  settings: {
-    registry: {
-      minLockLength: 720,
-      maxLockLength: 788400,
-      minNetworkJoinStakeAmount: 10000,
-      minGatewayJoinLength: 3600,
-      gatewayLeaveLength: 3600,
-      operatorStakeWithdrawLength: 3600,
-    },
-    auctions: baselineAuctionSettings,
-  },
-  gateways: {},
-  lastTickedHeight: 0,
-  observations: {},
-  demandFactoring: {
-    ...baselineDemandFactorData,
-    trailingPeriodPurchases:
-      baselineDemandFactorData.trailingPeriodPurchases.slice(),
-    trailingPeriodRevenues:
-      baselineDemandFactorData.trailingPeriodRevenues.slice(),
-  },
-});
-
-const baselineAuctionData: AuctionData = {
-  startHeight: 1,
-  startPrice: 1_000,
-  endHeight: 101,
-  floorPrice: 100,
-  type: 'lease',
-  initiator: 'initiator',
-  contractTxId: 'contractTxId',
-  years: 1,
-  settings: baselineAuctionSettings,
-};
-
-const baselineAuctionState: Partial<IOState> = {
-  auctions: {
-    'test-auction-close': {
-      ...baselineAuctionData,
-    },
-  },
-};
+import {
+  baselineAuctionData,
+  baselineAuctionSettings,
+  baselineAuctionState,
+  baselineDemandFactorData,
+  getBaselineState,
+} from '../../tests/stubs';
+import { AuctionData, IOState } from '../../types';
 
 describe('submitAuctionBid', () => {
   it.each([

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -113,8 +113,8 @@ export const submitAuctionBid = (
       startPrice: existingAuction.startPrice,
       floorPrice: existingAuction.floorPrice,
       currentBlockHeight: currentBlockHeight,
-      decayRate: existingAuction.settings.decayRate,
-      decayInterval: existingAuction.settings.decayInterval,
+      exponentialDecayRate: existingAuction.settings.exponentialDecayRate,
+      scalingExponent: existingAuction.settings.scalingExponent,
     });
 
     // we could throw an error if qty wasn't provided

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -1,5 +1,5 @@
 import {
-  calculateMinimumAuctionBid,
+  calculateAuctionPriceForBlock,
   createAuctionObject,
   getEndTimestampForAuction,
 } from '../../auctions';
@@ -108,7 +108,7 @@ export const submitAuctionBid = (
     }
 
     // calculate the current bid price and compare it to the floor price set by the initiator
-    const currentRequiredMinimumBid = calculateMinimumAuctionBid({
+    const currentRequiredMinimumBid = calculateAuctionPriceForBlock({
       startHeight: new BlockHeight(existingAuction.startHeight),
       startPrice: existingAuction.startPrice,
       floorPrice: existingAuction.floorPrice,

--- a/src/actions/write/tick.test.ts
+++ b/src/actions/write/tick.test.ts
@@ -21,8 +21,8 @@ import {
 
 const defaultAuctionSettings = {
   auctionDuration: 2,
-  decayInterval: 1,
-  decayRate: 0.5,
+  scalingExponent: 10,
+  exponentialDecayRate: 0.5,
   floorPriceMultiplier: 1,
   startPriceMultiplier: 10,
 };

--- a/src/auctions.test.ts
+++ b/src/auctions.test.ts
@@ -19,6 +19,9 @@ describe('Auction util functions', () => {
       [[0, 1, 0.002, 90], 83.511968],
       [[0, 2, 0.002, 90], 69.717284],
       [[0, 3, 0.002, 90], 58.180118],
+      // block heights before the start height should just return the start price
+      [[10, 9, 0.001, 90], 100],
+      [[10, 0, 0.001, 90], 100],
     ])(
       'given [current block height, moving average purchase count] of %j, should return %d',
       (

--- a/src/auctions.ts
+++ b/src/auctions.ts
@@ -58,15 +58,16 @@ export function getAuctionPricesForInterval({
     intervalBlockHeight <= auctionDuration;
     intervalBlockHeight += blocksPerInterval
   ) {
+    const blockHeightForInterval = startHeight.valueOf() + intervalBlockHeight;
     const price = calculateAuctionPriceForBlock({
       startHeight,
       startPrice,
       floorPrice,
-      currentBlockHeight: new BlockHeight(intervalBlockHeight),
+      currentBlockHeight: new BlockHeight(blockHeightForInterval),
       exponentialDecayRate,
       scalingExponent,
     });
-    prices[intervalBlockHeight] = price.valueOf();
+    prices[blockHeightForInterval] = price.valueOf();
   }
   return prices;
 }

--- a/src/auctions.ts
+++ b/src/auctions.ts
@@ -32,7 +32,9 @@ export function calculateMinimumAuctionBid({
   const dutchAuctionBid =
     startPrice * Math.pow(1 - decaySinceStart, scalingExponent);
   // TODO: we shouldn't be rounding like this, use a separate class to handle the number of allowed decimals for IO values and use them here
-  return new IOToken(Math.max(floorPrice, dutchAuctionBid));
+  return new IOToken(
+    Math.min(startPrice, Math.max(floorPrice, dutchAuctionBid)),
+  );
 }
 
 export function getAuctionPricesForInterval({

--- a/src/auctions.ts
+++ b/src/auctions.ts
@@ -12,7 +12,7 @@ import {
   RegistrationType,
 } from './types';
 
-export function calculateMinimumAuctionBid({
+export function calculateAuctionPriceForBlock({
   startHeight,
   startPrice,
   floorPrice,
@@ -58,7 +58,7 @@ export function getAuctionPricesForInterval({
     intervalBlockHeight <= auctionDuration;
     intervalBlockHeight += blocksPerInterval
   ) {
-    const price = calculateMinimumAuctionBid({
+    const price = calculateAuctionPriceForBlock({
       startHeight,
       startPrice,
       floorPrice,

--- a/src/auctions.ts
+++ b/src/auctions.ts
@@ -17,55 +17,54 @@ export function calculateMinimumAuctionBid({
   startPrice,
   floorPrice,
   currentBlockHeight,
-  decayInterval,
-  decayRate,
+  scalingExponent,
+  exponentialDecayRate,
 }: {
   startHeight: BlockHeight;
   startPrice: number;
   floorPrice: number;
   currentBlockHeight: BlockHeight;
-  decayInterval: number;
-  decayRate: number;
+  scalingExponent: number;
+  exponentialDecayRate: number;
 }): IOToken {
-  const blockIntervalsPassed = Math.max(
-    0,
-    Math.floor(
-      (currentBlockHeight.valueOf() - startHeight.valueOf()) / decayInterval,
-    ),
-  );
+  const blocksSinceStart = currentBlockHeight.valueOf() - startHeight.valueOf();
+  const decaySinceStart = exponentialDecayRate * blocksSinceStart;
   const dutchAuctionBid =
-    startPrice * Math.pow(1 - decayRate, blockIntervalsPassed);
+    startPrice * Math.pow(1 - decaySinceStart, scalingExponent);
   // TODO: we shouldn't be rounding like this, use a separate class to handle the number of allowed decimals for IO values and use them here
   return new IOToken(Math.max(floorPrice, dutchAuctionBid));
 }
 
-export function getAuctionPrices({
+export function getAuctionPricesForInterval({
   auctionSettings,
   startHeight,
   startPrice,
   floorPrice,
+  blocksPerInterval,
 }: {
   auctionSettings: AuctionSettings;
   startHeight: BlockHeight;
   startPrice: number;
   floorPrice: number;
+  blocksPerInterval: number;
 }): Record<number, number> {
-  const { auctionDuration, decayRate, decayInterval } = auctionSettings;
-  const intervalCount = auctionDuration / decayInterval;
+  const { auctionDuration, exponentialDecayRate, scalingExponent } =
+    auctionSettings;
   const prices: Record<number, number> = {};
-  for (let i = 0; i <= intervalCount; i++) {
-    const intervalHeight = new BlockHeight(
-      startHeight.valueOf() + i * decayInterval,
-    );
+  for (
+    let intervalBlockHeight = 0;
+    intervalBlockHeight <= auctionDuration;
+    intervalBlockHeight += blocksPerInterval
+  ) {
     const price = calculateMinimumAuctionBid({
       startHeight,
       startPrice,
       floorPrice,
-      currentBlockHeight: intervalHeight,
-      decayInterval,
-      decayRate,
+      currentBlockHeight: new BlockHeight(intervalBlockHeight),
+      exponentialDecayRate,
+      scalingExponent,
     });
-    prices[intervalHeight.valueOf()] = price.valueOf();
+    prices[intervalBlockHeight] = price.valueOf();
   }
   return prices;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,8 +116,8 @@ export const FEE_STRUCTURE = {
 export const AUCTION_SETTINGS: AuctionSettings = {
   floorPriceMultiplier: 1,
   startPriceMultiplier: 50,
-  exponentialDecayRate: 0.000005,
-  scalingExponent: 90,
+  exponentialDecayRate: 0.000002,
+  scalingExponent: 190,
   auctionDuration: 10_080, // approx 14 days long
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,8 +116,8 @@ export const FEE_STRUCTURE = {
 export const AUCTION_SETTINGS: AuctionSettings = {
   floorPriceMultiplier: 1,
   startPriceMultiplier: 50,
-  decayInterval: 30, // decrement every 30 blocks - approx every 1 hour
-  decayRate: 0.0225, // 2.25% decay per interval
+  exponentialDecayRate: 0.000005,
+  scalingExponent: 90,
   auctionDuration: 10_080, // approx 14 days long
 };
 

--- a/src/tests/stubs.ts
+++ b/src/tests/stubs.ts
@@ -1,0 +1,77 @@
+import { FEE_STRUCTURE } from '../constants';
+import { AuctionData, DemandFactoringData, IOState } from '../types';
+
+export const baselineDemandFactorData: DemandFactoringData = {
+  periodZeroBlockHeight: 0,
+  currentPeriod: 0,
+  trailingPeriodPurchases: [0, 0, 0, 0, 0, 0, 0],
+  trailingPeriodRevenues: [0, 0, 0, 0, 0, 0, 0],
+  purchasesThisPeriod: 0,
+  revenueThisPeriod: 0,
+  demandFactor: 1,
+  consecutivePeriodsWithMinDemandFactor: 0,
+};
+
+export const baselineAuctionSettings = {
+  auctionDuration: 100,
+  scalingExponent: 10,
+  exponentialDecayRate: 0.001,
+  startPriceMultiplier: 100,
+  floorPriceMultiplier: 1,
+};
+
+export const getBaselineState = (): IOState => ({
+  ticker: 'ARNS-TEST',
+  name: 'Arweave Name System Test',
+  canEvolve: true,
+  owner: '',
+  evolve: '',
+  records: {},
+  balances: {},
+  reserved: {},
+  fees: {
+    ...FEE_STRUCTURE,
+  },
+  auctions: {},
+  settings: {
+    registry: {
+      minLockLength: 720,
+      maxLockLength: 788400,
+      minNetworkJoinStakeAmount: 10000,
+      minGatewayJoinLength: 3600,
+      gatewayLeaveLength: 3600,
+      operatorStakeWithdrawLength: 3600,
+    },
+    auctions: baselineAuctionSettings,
+  },
+  gateways: {},
+  lastTickedHeight: 0,
+  observations: {},
+  demandFactoring: {
+    ...baselineDemandFactorData,
+    trailingPeriodPurchases:
+      baselineDemandFactorData.trailingPeriodPurchases.slice(),
+    trailingPeriodRevenues:
+      baselineDemandFactorData.trailingPeriodRevenues.slice(),
+  },
+});
+
+export const baselineAuctionData: AuctionData = {
+  startHeight: 1,
+  startPrice: 1_000,
+  endHeight: 101,
+  floorPrice: 100,
+  type: 'lease',
+  initiator: 'initiator',
+  contractTxId: 'contractTxId',
+  years: 1,
+  settings: baselineAuctionSettings,
+};
+
+export const baselineAuctionState: Partial<IOState> = {
+  auctions: {
+    'test-auction-close': {
+      ...baselineAuctionData,
+    },
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,11 +78,11 @@ export type AuctionData = {
 
 // TODO: Since we're not allowing mutability of this via governance, we could do away with ID-based settings
 export type AuctionSettings = {
-  floorPriceMultiplier: number; // if we ever want to drop prices
+  floorPriceMultiplier: number;
   startPriceMultiplier: number;
+  scalingExponent: number; // the constant used to scale the price of the auction
   auctionDuration: number;
-  decayRate: number;
-  decayInterval: number;
+  exponentialDecayRate: number; // the rate at which the price drops for each block
 };
 
 export type GatewayRegistrySettings = {

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -627,24 +627,6 @@ describe('Auctions', () => {
           auctionTxId = writeInteraction.originalTxId;
         });
 
-        it.each([0, 10, 19, 20, 69])(
-          `should expect the bid amount to not exceed the start price after %s blocks`,
-          async (block) => {
-            const winningBidQty = calculateMinimumAuctionBid({
-              startHeight: new BlockHeight(auctionObj.startHeight),
-              startPrice: auctionObj.startPrice,
-              floorPrice: auctionObj.floorPrice,
-              scalingExponent: AUCTION_SETTINGS.scalingExponent,
-              exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
-              currentBlockHeight: new BlockHeight(
-                auctionObj.startHeight + block,
-              ),
-            }).valueOf();
-
-            expect(winningBidQty).toBeLessThanOrEqual(auctionObj.startPrice);
-          },
-        );
-
         it('should update the records when the caller is the initiator, and only withdraw the difference of the current bid to the original floor price that was already withdrawn from the initiator', async () => {
           // fast forward a few blocks, then construct winning bid
           await mineBlocks(arweave, 5);

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -6,7 +6,7 @@ import {
   WriteInteractionResponse,
 } from 'warp-contracts';
 
-import { calculateMinimumAuctionBid } from '../src/auctions';
+import { calculateAuctionPriceForBlock } from '../src/auctions';
 import {
   ARNS_NAME_RESERVED_MESSAGE,
   AUCTION_SETTINGS,
@@ -268,7 +268,7 @@ describe('Auctions', () => {
                 if (!auctionObj) {
                   throw new Error('auctionObj is undefined');
                 }
-                const winningBidQty = calculateMinimumAuctionBid({
+                const winningBidQty = calculateAuctionPriceForBlock({
                   startHeight: new BlockHeight(auctionObj.startHeight),
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
@@ -291,7 +291,7 @@ describe('Auctions', () => {
                   function: 'submitAuctionBid',
                   ...auctionBid,
                 });
-                const pricePaidForBlock = calculateMinimumAuctionBid({
+                const pricePaidForBlock = calculateAuctionPriceForBlock({
                   startHeight: new BlockHeight(auctionObj.startHeight),
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
@@ -519,7 +519,7 @@ describe('Auctions', () => {
 
           // fast forward to lower auction price
           await mineBlocks(arweave, 5);
-          const winningBidQty = calculateMinimumAuctionBid({
+          const winningBidQty = calculateAuctionPriceForBlock({
             startHeight: new BlockHeight(auctionObj.startHeight),
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
@@ -542,7 +542,7 @@ describe('Auctions', () => {
             function: 'submitAuctionBid',
             ...auctionBid,
           });
-          const pricePaidForBlock = calculateMinimumAuctionBid({
+          const pricePaidForBlock = calculateAuctionPriceForBlock({
             startHeight: new BlockHeight(auctionObj.startHeight),
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
@@ -630,7 +630,7 @@ describe('Auctions', () => {
         it('should update the records when the caller is the initiator, and only withdraw the difference of the current bid to the original floor price that was already withdrawn from the initiator', async () => {
           // fast forward a few blocks, then construct winning bid
           await mineBlocks(arweave, 5);
-          const winningBidQty = calculateMinimumAuctionBid({
+          const winningBidQty = calculateAuctionPriceForBlock({
             startHeight: new BlockHeight(auctionObj.startHeight),
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
@@ -648,7 +648,7 @@ describe('Auctions', () => {
             ...auctionBid,
           });
           // we always take the lesser of the submitted and the cost of auction at a given block
-          const pricePaidForBlock = calculateMinimumAuctionBid({
+          const pricePaidForBlock = calculateAuctionPriceForBlock({
             startHeight: new BlockHeight(auctionObj.startHeight),
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,


### PR DESCRIPTION
Every block will have a unique price based on the provided auction settings. To support compatibility with the portal, the read function for auctions will continue to return interval based pricing. We will add a field to the response that contains the function a client can use to calculate the price of an auction at a given block height so they can generate prices locally without having the hit the service for a price for each block

Related portal changes: https://github.com/ar-io/arns-react/pull/349

Note: this requires an `evolveState` to be run once the evolution has happened