### PR TITLE
fix(PE-5020): do not tick state on evolve interactions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: develop
     strategy:
       matrix:
         step: ['format:check', 'lint:check', 'build', 'test']
@@ -21,3 +22,5 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn ${{ matrix.step }}
+        env:
+          ARNS_CONTRACT_TX_ID: ${{ vars.ARNS_CONTRACT_TX_ID }}

--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
     strategy:
       matrix:
         step: ['format:check', 'lint:check', 'build', 'test']
@@ -24,6 +25,9 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn ${{ matrix.step }}
+        env:
+          ARNS_CONTRACT_TX_ID: ${{ vars.ARNS_CONTRACT_TX_ID }}
+
   evolve:
     runs-on: ubuntu-latest
     needs: [build]

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -19,6 +19,12 @@ export const evolveState = async (
   // update the auction settings object
   state.settings.auctions = AUCTION_SETTINGS;
 
+  // transfer the forked states balance to the new one and delete the old balance
+  state.balances[+SmartWeave.contract.id] +=
+    state.balances['3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI'];
+
+  delete state.balances['3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI'];
+
   // TODO: Should this be using previous contracts DF values?
   // update demand factoring
   state.demandFactoring = {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -16,8 +16,8 @@ import { getPriceForInteraction } from './actions/read/price';
 import { getRecord } from './actions/read/record';
 import { buyRecord } from './actions/write/buyRecord';
 import { decreaseOperatorStake } from './actions/write/decreaseOperatorStake';
-import { evolve } from './actions/write/evolve';
-import { evolveState } from './actions/write/evolveState';
+// import { evolve } from './actions/write/evolve';
+// import { evolveState } from './actions/write/evolveState';
 import { extendRecord } from './actions/write/extendRecord';
 import { increaseOperatorStake } from './actions/write/increaseOperatorStake';
 import { increaseUndernameCount } from './actions/write/increaseUndernameCount';
@@ -41,16 +41,6 @@ export async function handle(
   action: PstAction,
 ): Promise<ContractReadResult | ContractWriteResult> {
   const input = action.input;
-
-  // don't tick on evolutions, it should only update the source code transaction
-  if (input.function === 'evolve') {
-    return evolve(state, action);
-  }
-
-  // TODO: this is an interaction specific for testing and updating state without having to fork the contract, it should be removed for mainnet deployment
-  if (input.function === 'evolveState') {
-    return evolveState(state, action);
-  }
 
   // all the remaining interactions require a ticked state, even when reading, so users get the most recent evaluation
   const { state: tickedState } = await tick(state);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -52,11 +52,6 @@ export async function handle(
     return evolveState(state, action);
   }
 
-  // directly call tick for tick interaction
-  if (input.function === 'tick') {
-    return tick(state);
-  }
-
   // all the remaining interactions require a ticked state, even when reading, so users get the most recent evaluation
   const { state: tickedState } = await tick(state);
 
@@ -99,6 +94,9 @@ export async function handle(
       return submitAuctionBid(tickedState, action);
     case 'auction':
       return getAuction(tickedState, action);
+    case 'tick':
+      // we already ticked, so just return the state
+      return { state: tickedState };
     case 'saveObservations':
       return saveObservations(tickedState, action);
     case 'priceForInteraction':

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -16,8 +16,8 @@ import { getPriceForInteraction } from './actions/read/price';
 import { getRecord } from './actions/read/record';
 import { buyRecord } from './actions/write/buyRecord';
 import { decreaseOperatorStake } from './actions/write/decreaseOperatorStake';
-// import { evolve } from './actions/write/evolve';
-// import { evolveState } from './actions/write/evolveState';
+import { evolve } from './actions/write/evolve';
+import { evolveState } from './actions/write/evolveState';
 import { extendRecord } from './actions/write/extendRecord';
 import { increaseOperatorStake } from './actions/write/increaseOperatorStake';
 import { increaseUndernameCount } from './actions/write/increaseUndernameCount';
@@ -41,6 +41,16 @@ export async function handle(
   action: PstAction,
 ): Promise<ContractReadResult | ContractWriteResult> {
   const input = action.input;
+
+  // don't tick on evolutions, it should only update the source code transaction
+  if (input.function === 'evolve') {
+    return evolve(state, action);
+  }
+
+  // TODO: this is an interaction specific for testing and updating state without having to fork the contract, it should be removed for mainnet deployment
+  if (input.function === 'evolveState') {
+    return evolveState(state, action);
+  }
 
   // all the remaining interactions require a ticked state, even when reading, so users get the most recent evaluation
   const { state: tickedState } = await tick(state);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -42,7 +42,22 @@ export async function handle(
 ): Promise<ContractReadResult | ContractWriteResult> {
   const input = action.input;
 
-  // tick state on any interaction, even when reading, so users get the most recent evaluation
+  // don't tick on evolutions, it should only update the source code transaction
+  if (input.function === 'evolve') {
+    return evolve(state, action);
+  }
+
+  // TODO: this is an interaction specific for testing and updating state without having to fork the contract, it should be removed for mainnet deployment
+  if (input.function === 'evolveState') {
+    return evolveState(state, action);
+  }
+
+  // directly call tick for tick interaction
+  if (input.function === 'tick') {
+    return tick(state);
+  }
+
+  // all the remaining interactions require a ticked state, even when reading, so users get the most recent evaluation
   const { state: tickedState } = await tick(state);
 
   switch (input.function as IOContractFunctions) {
@@ -54,10 +69,6 @@ export async function handle(
       return extendRecord(tickedState, action);
     case 'increaseUndernameCount':
       return increaseUndernameCount(tickedState, action);
-    case 'evolve':
-      return evolve(tickedState, action);
-    case 'evolveState':
-      return evolveState(tickedState, action);
     case 'balance':
       return balance(tickedState, action);
     case 'record':
@@ -92,8 +103,6 @@ export async function handle(
       return saveObservations(tickedState, action);
     case 'priceForInteraction':
       return getPriceForInteraction(tickedState, action);
-    case 'tick':
-      return tick(tickedState);
     default:
       throw new ContractError(
         `No function supplied or function not recognized: "${input.function}"`,

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -20,7 +20,7 @@ import { AuctionData, BlockHeight, IOState } from '../src/types';
 import { ANT_CONTRACT_IDS } from './utils/constants';
 import {
   getCurrentBlock,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
   mineBlocks,
 } from './utils/helper';
@@ -31,7 +31,7 @@ describe('Auctions', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('any address', () => {

--- a/tests/balance.test.ts
+++ b/tests/balance.test.ts
@@ -1,7 +1,7 @@
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
-import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
+import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
 import { arweave, warp } from './utils/services';
 
 describe('Balance', () => {
@@ -9,7 +9,7 @@ describe('Balance', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('non-contract owner', () => {

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -1,0 +1,63 @@
+import { Contract, JWKInterface, PstState } from 'warp-contracts';
+
+import {
+  arweave,
+  getContractManifest,
+  warp as warpMainnet,
+} from '../tools/utilities';
+import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
+import { arweave as arweaveLocal, warp as warpLocal } from './utils/services';
+
+const testnetContractTxId =
+  process.env.ARNS_CONTRACT_TX_ID ??
+  '3aX8Ck5_IRLA3L9o4BJLOWxJDrmLLIPoUGZxqOfmHDI';
+
+describe('evolving contract', () => {
+  let contractOwner: JWKInterface;
+  let contract: Contract<PstState>;
+  let srcContractId: string;
+
+  beforeAll(async () => {
+    srcContractId = getLocalArNSContractKey('srcTxId');
+    contractOwner = getLocalWallet(0);
+
+    // get the existing contract state
+    const { evaluationOptions = {} } = await getContractManifest({
+      arweave,
+      contractTxId: testnetContractTxId,
+    });
+    const testnetContract = await warpMainnet
+      .contract(testnetContractTxId)
+      .setEvaluationOptions(evaluationOptions)
+      .syncState(`https://api.arns.app/v1/contract/${testnetContractTxId}`);
+    const { cachedValue } = await testnetContract.readState();
+
+    const ownerAddress = await arweaveLocal.wallets.jwkToAddress(contractOwner);
+
+    // deploy a new contract locally against the existing contract state to test that evolve will not break
+    const { contractTxId: newContractTxId } =
+      await warpLocal.deployFromSourceTx(
+        {
+          wallet: contractOwner,
+          initState: JSON.stringify({
+            ...(cachedValue.state as any),
+            owner: ownerAddress,
+            evolve: null,
+          }),
+          srcTxId: srcContractId,
+        },
+        true,
+      );
+    contract = warpLocal.pst(newContractTxId).connect(contractOwner);
+  });
+
+  it('should be able to evolve the existing arns contract with the new contract source code', async () => {
+    const writeInteraction = await contract.evolve(srcContractId);
+    expect(writeInteraction.originalTxId).not.toBeUndefined();
+    const { cachedValue } = await contract.readState();
+    expect(Object.keys(cachedValue.errorMessages)).not.toContain(
+      writeInteraction.originalTxId,
+    );
+    expect(cachedValue.state.evolve).toBe(srcContractId);
+  });
+});

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   addFunds,
   calculateAnnualRenewalFee,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
 } from './utils/helper';
 import { arweave, warp } from './utils/services';
@@ -23,7 +23,7 @@ describe('Extend', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('contract owner', () => {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -10,7 +10,7 @@ import {
 } from './utils/constants';
 import {
   getCurrentBlock,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
   mineBlocks,
 } from './utils/helper';
@@ -24,7 +24,7 @@ describe('Network', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('valid gateway operator', () => {

--- a/tests/observation.test.ts
+++ b/tests/observation.test.ts
@@ -13,7 +13,7 @@ import {
   createLocalWallet,
   getCurrentBlock,
   getEpochStart,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
   getRandomFailedGatewaysSubset,
   mineBlock,
@@ -42,7 +42,7 @@ describe('Observation', () => {
       });
       gatewayWalletAddresses.push(gatewayWalletAddress);
     }
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
     contract = warp.pst(srcContractId);
   });
 

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -14,7 +14,7 @@ import {
 import {
   calculatePermabuyFee,
   calculateRegistrationFee,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
 } from './utils/helper';
 import { arweave, warp } from './utils/services';
@@ -24,7 +24,7 @@ describe('Records', () => {
   let srcContractId: string;
 
   beforeAll(() => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
     contract = warp.pst(srcContractId);
   });
 

--- a/tests/setup.jest.ts
+++ b/tests/setup.jest.ts
@@ -5,9 +5,10 @@ import { WALLETS_TO_CREATE } from './utils/constants';
 import { createLocalWallet, setupInitialContractState } from './utils/helper';
 import { arlocal, arweave, warp } from './utils/services';
 
+/* eslint-disable no-console */
 module.exports = async () => {
   // start arlocal
-  console.log('\n\nSetting up Warp, Arlocal and Arweave clients...'); // eslint-disable-line
+  console.log('\n\nSetting up Warp, Arlocal and Arweave clients...');
 
   await arlocal.start();
 
@@ -25,7 +26,7 @@ module.exports = async () => {
     wallets.push(await createLocalWallet(arweave));
   }
   // save wallets to disk
-  console.log('Saving wallets to disk!'); // eslint-disable-line
+  console.log('Saving wallets to disk!');
 
   wallets.forEach((w, index) => {
     fs.writeFileSync(
@@ -34,7 +35,7 @@ module.exports = async () => {
     );
   });
 
-  console.log('Successfully created wallets!'); // eslint-disable-line
+  console.log('Successfully created wallets!');
 
   // create initial contract
   const initialContractState = await setupInitialContractState(
@@ -42,10 +43,10 @@ module.exports = async () => {
     wallets.map((w) => w.address),
   );
 
-  console.log('Successfully created initial contract state!'); // eslint-disable-line
+  console.log('Successfully created initial contract state!');
 
   // deploy contract to arlocal
-  const { contractTxId } = await warp.deploy(
+  const { contractTxId, srcTxId } = await warp.deploy(
     {
       wallet: wallets[0].wallet,
       initState: JSON.stringify(initialContractState),
@@ -53,6 +54,11 @@ module.exports = async () => {
     },
     true,
   ); // disable bundling
+
+  console.log('Successfully deployed contract!', {
+    contractTxId,
+    srcTxId,
+  });
 
   // transfer funds to the protocol balance
   await warp.pst(contractTxId).connect(wallets[0].wallet).writeInteraction({
@@ -67,10 +73,11 @@ module.exports = async () => {
     JSON.stringify({
       initialContractState,
       id: contractTxId,
+      srcTxId: srcTxId,
     }),
   );
 
-  console.log('Successfully setup ArLocal and deployed contract.'); // eslint-disable-line
+  console.log('Successfully setup ArLocal and deployed contract.');
 };
 
 function createDirectories() {

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -7,7 +7,7 @@ import {
   INVALID_TARGET_MESSAGE,
   TRANSFER_QTY,
 } from './utils/constants';
-import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
+import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
 import { arweave, warp } from './utils/services';
 
 describe('Transfers', () => {
@@ -15,7 +15,7 @@ describe('Transfers', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('contract owner', () => {

--- a/tests/undernames.test.ts
+++ b/tests/undernames.test.ts
@@ -8,7 +8,7 @@ import {
 import { IOState } from '../src/types';
 import {
   calculateUndernamePermutations,
-  getLocalArNSContractId,
+  getLocalArNSContractKey,
   getLocalWallet,
 } from './utils/helper';
 import { warp } from './utils/services';
@@ -18,7 +18,7 @@ describe('undernames', () => {
   let srcContractId: string;
 
   beforeAll(async () => {
-    srcContractId = getLocalArNSContractId();
+    srcContractId = getLocalArNSContractKey('id');
   });
 
   describe('any address', () => {

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -389,14 +389,14 @@ export function getLocalWallet(index = 0): JWKInterface {
   return wallet;
 }
 
-export function getLocalArNSContractId(): string {
+export function getLocalArNSContractKey(key: 'srcTxId' | 'id' = 'id'): string {
   const contract = JSON.parse(
     fs.readFileSync(
       path.join(__dirname, `../contract/arns_contract.json`),
       'utf8',
     ),
-  ) as unknown as IOState & { id: string };
-  return contract.id;
+  ) as unknown as IOState & { id: string; srcTxId: string };
+  return contract[key];
 }
 
 export function getRandomFailedGatewaysSubset(


### PR DESCRIPTION
This can lead to bricking of state if the evolved contract fails to support new state fields that did not previously exist, and error when `tickState` is called for any interaction.

✅ added an additional CI/CD test that deploys a new contract from old contract state, and runs evolve against it to confirm that the `evolve` mechanism with updated code does not brick the contract.