### PR TITLE
fix(tick): remove `safeArweaveGet` from `tick`

### DIFF
--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -26,8 +26,5 @@ export const evolveState = async (
     };
   }
 
-  // TODO: remove this
-  state.lastTickedHeight = +SmartWeave.block.height;
-
   return { state };
 };

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -286,7 +286,7 @@ export function tickAuctions({
 // Removes gateway from the gateway address registry after the leave period completes
 export const tick = async (state: IOState): Promise<ContractWriteResult> => {
   const interactionHeight = new BlockHeight(+SmartWeave.block.height);
-
+  const interactionTimestamp = new BlockTimestamp(+SmartWeave.block.timestamp);
   if (interactionHeight.valueOf() === state.lastTickedHeight) {
     return { state };
   }
@@ -307,13 +307,12 @@ export const tick = async (state: IOState): Promise<ContractWriteResult> => {
     tickHeight++
   ) {
     const currentBlockHeight = new BlockHeight(tickHeight);
-    const safeBlock = await SmartWeave.safeArweaveGet(
-      `/block/height/${tickHeight}`,
-    );
-    const currentBlockTimestamp = new BlockTimestamp(safeBlock.timestamp);
+    /**
+     * TODO: once safeArweaveGet is more reliable, we can get the timestamp from the block between ticks to provide the timestamp. We are currently experiencing 'timeout' errors on evaluations for large gaps between interactions so we cannot reliably trust it with the current implementation.
+     * */
     updatedState = tickInternal({
       currentBlockHeight,
-      currentBlockTimestamp,
+      currentBlockTimestamp: interactionTimestamp,
       state: updatedState,
     });
   }

--- a/tests/mocks.jest.ts
+++ b/tests/mocks.jest.ts
@@ -13,6 +13,8 @@ SmartWeave = {
   transaction: {
     id: 'stubbed-transaction-id',
   },
+  // tests should implement their own mocks for safeArweaveGet depending on their needs and avoid a global mock that could hide potential bugs
+  safeArweaveGet: jest.fn().mockRejectedValue('safeArweaveGet not implemented'),
 };
 
 // map it to a standard error


### PR DESCRIPTION
We cannot reliably use it as it causes `timeout` issues when there are large intervals for ticking state. We will look to reintroduce once various optimziations can be made to the endpoint and warp evaluations