### PR TITLE
chore(github): add `evolve:state` step to evolve action

### DIFF
--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -2,6 +2,12 @@ name: Build / Test / Evolve Contract
 
 on:
   workflow_dispatch:
+    inputs:
+      evolve-state-tx-id:
+        description: 'Confirm the source code transaction ID you are running evolve state against.'
+        required: false
+        type: string
+        default: null
   push:
     branches:
       - develop
@@ -34,6 +40,10 @@ jobs:
     environment: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
       - run: yarn install
       - run: yarn build
       - id: evolve
@@ -46,3 +56,33 @@ jobs:
       - run: |
           git tag "${{ steps.evolve.outputs.srcTxId }}"
           git push --tags
+
+  evolve-state:
+    if: github.event.inputs.evolve-state-tx-id != null
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
+      - name: Validate Input
+        run: |
+          SOURCE_CODE_TX_ID=$(curl https://api.arns.app/v1/contract/${{ vars.ARNS_CONTRACT_TX_ID }} | jq -r '.state.evolve')
+          if [ -z "${{ github.event.inputs.evolve-state-tx-id }}" ]; then
+            echo "No evolve-state-tx-id provided. Exiting."
+            exit 1
+          fi
+
+          if [ "${{ github.event.inputs.evolve-state-tx-id }}" = "$SOURCE_CODE_TX_ID" ]; then
+            echo "The evolve-state-tx-id the current source code TX ID of the contract. Evolving state..."
+          else
+            echo "The evolve-state-tx-id does not match the current source code TX ID of the contract. Exiting."
+            exit 1
+          fi
+      - run: yarn install
+      - run: yarn evolve:state
+        env:
+          ARNS_CONTRACT_TX_ID: ${{ vars.ARNS_CONTRACT_TX_ID }}
+          JWK: ${{ secrets.JWK }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:integration": "yarn build && jest --testPathPattern=tests --globalSetup=./tests/setup.jest.ts --globalTeardown=./tests/teardown.jest.ts --runInBand",
     "test": "yarn build && yarn test:unit ; yarn test:integration",
     "evolve": "yarn ts-node ./tools/evolve-contract.ts",
+    "evolve:state": "yarn ts-node ./tools/evolve-state.ts",
     "tick": "yarn ts-node ./tools/tick.ts",
     "prepare": "husky install",
     "pre-commit": "lint-staged"


### PR DESCRIPTION
It accepts the source code TX ID you expect to run the evolveState function against. If they do not match, then the step will fail. This should help protect against uninteneded evolves and moves the reliance on local evolutions. We can eventually combine these and wait until the contract shows the updated evolve field, but that will require waiting in the github action and chewing up minutes. We can just do it manually for now - and avoids potential mistakes running it locally.