### PR TITLE
chore(github): use reusable workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,11 +1,6 @@
 name: Build and Test
 
-on:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
-      - develop
+on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   build:

--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -12,21 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    environment: ${{ github.ref_name }}
-    strategy:
-      matrix:
-        step: ['format:check', 'lint:check', 'build', 'test']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .nvmrc
-          cache: 'yarn'
-      - run: yarn install
-      - run: yarn ${{ matrix.step }}
-        env:
-          ARNS_CONTRACT_TX_ID: ${{ vars.ARNS_CONTRACT_TX_ID }}
+    uses: ./.github/workflows/build_and_test.yml
 
   evolve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will ensure coverage reports get submitted on deployment branches and reduces duplicate calls in evolve workflow