### PR TITLE
fix: modify constants for devnet

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,12 +58,14 @@ export const INVALID_GATEWAY_EXISTS_MESSAGE =
   'A gateway with this address already exists.';
 export const DEFAULT_NUM_SAMPLED_BLOCKS = 3;
 export const DEFAULT_SAMPLED_BLOCKS_OFFSET = 50;
-export const TALLY_PERIOD_BLOCKS = 100;
+export const DEFAULT_EPOCH_BLOCK_LENGTH = 50; // TODO: make this 5000 for testnet
+export const DEFAULT_START_HEIGHT = 0; // TODO: this should be coordinated with the genesis block height
+export const TALLY_PERIOD_BLOCKS = DEFAULT_EPOCH_BLOCK_LENGTH / 2; // TODO: set this to 100 for testnet
 export const EPOCH_REWARD_PERCENTAGE = 0.0025; // 0.25% of total available protocol balance
 export const GATEWAY_PERCENTAGE_OF_EPOCH_REWARD = 0.95;
 export const OBSERVATION_FAILURE_THRESHOLD = 0.51;
 export const BAD_OBSERVER_GATEWAY_PENALTY = 0.25;
-export const MAXIMUM_OBSERVERS_PER_EPOCH = 4; // TODO: CHANGE THIS TO 50 for testnet
+export const MAXIMUM_OBSERVERS_PER_EPOCH = 4; // TODO: set this to 50 for testnet
 export const NON_EXPIRED_ARNS_NAME_MESSAGE =
   'This name already exists in an active lease';
 export const ARNS_NAME_DOES_NOT_EXIST_MESSAGE =
@@ -156,8 +158,6 @@ export const AUCTION_SETTINGS: AuctionSettings = {
   scalingExponent: 190,
   auctionDuration: 10_080, // approx 14 days long
 };
-export const DEFAULT_EPOCH_BLOCK_LENGTH = 50; // TODO: make this 5000 for testnet
-export const DEFAULT_START_HEIGHT = 0; // TODO: this should be coordinated with the genesis block height
 export const MAX_TENURE_WEIGHT = 4; // 4 - 6 month periods mark you as a mature gateway
 export type DemandFactoringCriteria = 'purchases' | 'revenue';
 type DemandFactoringSettings = {


### PR DESCRIPTION
We will shorten the tally period for devnet. Otherwise, distributions will lag way behind epoch end heights.