### PR TITLE
fix(PE-5459): fix MAJOR bug in prescribed observers related to composite weights

### DIFF
--- a/src/actions/read/observation.ts
+++ b/src/actions/read/observation.ts
@@ -3,7 +3,6 @@ import {
   TALLY_PERIOD_BLOCKS,
 } from '../../constants';
 import {
-  getEligibleGatewaysForEpoch,
   getEpochBoundariesForHeight,
   getPrescribedObserversForEpoch,
 } from '../../observers';
@@ -40,16 +39,11 @@ export const prescribedObserver = async (
       epochBlockLength: new BlockHeight(DEFAULT_EPOCH_BLOCK_LENGTH),
     });
 
-  const eligibleGateways = getEligibleGatewaysForEpoch({
+  const prescribedObservers = await getPrescribedObserversForEpoch({
+    gateways,
+    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
     epochEndHeight,
-    gateways,
-  });
-
-  const prescribedObservers = await getPrescribedObserversForEpoch({
-    eligibleGateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
-    epochStartHeight: epochStartHeight,
     distributions,
   });
 
@@ -88,16 +82,11 @@ export const prescribedObservers = async (
       epochBlockLength: new BlockHeight(DEFAULT_EPOCH_BLOCK_LENGTH),
     });
 
-  const eligibleGateways = getEligibleGatewaysForEpoch({
+  const prescribedObservers = await getPrescribedObserversForEpoch({
+    gateways,
+    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
     epochEndHeight,
-    gateways,
-  });
-
-  const prescribedObservers = await getPrescribedObserversForEpoch({
-    eligibleGateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
-    epochStartHeight: epochStartHeight,
     distributions,
   });
 

--- a/src/actions/write/saveObservations.ts
+++ b/src/actions/write/saveObservations.ts
@@ -6,7 +6,6 @@ import {
   NETWORK_JOIN_STATUS,
 } from '../../constants';
 import {
-  getEligibleGatewaysForEpoch,
   getEpochBoundariesForHeight,
   getPrescribedObserversForEpoch,
 } from '../../observers';
@@ -94,17 +93,11 @@ export const saveObservations = async (
     throw new ContractError(INVALID_OBSERVATION_CALLER_MESSAGE);
   }
 
-  // filter out gateways eligible for epoch distribution
-  const eligibleGateways = getEligibleGatewaysForEpoch({
-    epochStartHeight,
-    epochEndHeight,
-    gateways,
-  });
-
   const prescribedObservers = await getPrescribedObserversForEpoch({
-    eligibleGateways,
+    gateways,
     minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
+    epochEndHeight,
     distributions,
   });
 

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -458,7 +458,6 @@ export async function tickRewardDistribution({
     totalReportsSubmitted * OBSERVATION_FAILURE_THRESHOLD,
   );
 
-  // filter out gateways eligible for epoch distribution
   const eligibleGateways = getEligibleGatewaysForEpoch({
     epochStartHeight,
     epochEndHeight,
@@ -467,8 +466,9 @@ export async function tickRewardDistribution({
 
   // get the observers for the epoch
   const prescribedObservers = await getPrescribedObserversForEpoch({
-    eligibleGateways,
+    gateways,
     epochStartHeight,
+    epochEndHeight,
     minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     distributions,
   });

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -183,7 +183,7 @@ describe('getPrescribedObserversForEpoch', () => {
     expect(observers).toEqual(expectedObservers);
   });
 
-  it('should filter out gateways that have not passed any epochs', async () => {
+  it('should still include gateways that have not passed any epochs, with adjusted composite weights', async () => {
     const epochStartHeight = 10;
     const appendedGateways: DeepReadonly<Gateways> = {
       ...gateways,
@@ -275,11 +275,15 @@ describe('getPrescribedObserversForEpoch', () => {
       epochEndHeight: new BlockHeight(epochStartHeight + 10),
     });
 
-    expect(observers.length).toEqual(2);
-    expect(observers.map((o) => o.gatewayAddress)).toEqual([
-      'test-observer-wallet-1',
-      'test-observer-wallet-2',
-    ]);
+    expect(observers.length).toEqual(MAXIMUM_OBSERVERS_PER_EPOCH);
+    expect(observers.map((o) => o.gatewayAddress)).toEqual(
+      expect.arrayContaining([
+        'test-observer-wallet-1',
+        'test-observer-wallet-2',
+        'test-observer-wallet-3',
+        'test-observer-wallet-4',
+      ]),
+    );
   });
 });
 

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -68,7 +68,7 @@ describe('getPrescribedObserversForEpoch', () => {
     jest.resetAllMocks();
   });
 
-  it('should return the all eligible observers with proper weights if less than the number required', async () => {
+  it(`should return the all eligible observers with proper weights if the total number is less than ${MAXIMUM_OBSERVERS_PER_EPOCH}`, async () => {
     const epochStartHeight = 10;
     const totalStake = 100;
     const minNetworkJoinStakeAmount = 10;
@@ -108,7 +108,7 @@ describe('getPrescribedObserversForEpoch', () => {
     ]);
   });
 
-  it('should return the correct number observers with proper weights if there are more gateways with composite scores greater than 0', async () => {
+  it(`should return the correct number observers with proper weights if there are more than ${MAXIMUM_OBSERVERS_PER_EPOCH} gateways with composite scores greater than 0`, async () => {
     const epochStartHeight = 10;
     const eligibleGateways: DeepReadonly<Gateways> = {
       ...gateways,
@@ -133,7 +133,7 @@ describe('getPrescribedObserversForEpoch', () => {
     };
     const minNetworkJoinStakeAmount = 10;
     const observers = await getPrescribedObserversForEpoch({
-      gateways,
+      gateways: eligibleGateways,
       distributions,
       minNetworkJoinStakeAmount: 10,
       epochStartHeight: new BlockHeight(epochStartHeight),

--- a/src/observers.ts
+++ b/src/observers.ts
@@ -174,22 +174,18 @@ export async function getPrescribedObserversForEpoch({
       distributions.gateways[address]?.passedEpochCount || 0;
     const totalEpochsParticipatedIn =
       distributions.gateways[address]?.totalEpochParticipationCount || 0;
-    // TODO: should we default to 1 here even if they have never passed an epoch to avoid a 0 composite score?
     // default to 1 for gateways that have not participated in a full epoch
-    const gatewayRewardRatioWeight = totalEpochsParticipatedIn
-      ? totalEpochsGatewayPassed / totalEpochsParticipatedIn
-      : 1; // NOTE: this could be reduced
+    const gatewayRewardRatioWeight =
+      (1 + totalEpochsGatewayPassed) / (1 + totalEpochsParticipatedIn);
 
     // the percentage of epochs the observer was prescribed and submitted reports for
     const totalEpochsPrescribed =
       distributions.observers[address]?.totalEpochsPrescribedCount || 0;
     const totalEpochsSubmitted =
       distributions.observers[address]?.submittedEpochCount || 0;
-    // TODO: should we default to 1 here even if they have never submitted a report to avoid a 0 composite score?
     // defaults to one again if either are 0, encouraging new gateways to join and observe
-    const observerRewardRatioWeight = totalEpochsPrescribed
-      ? totalEpochsSubmitted / totalEpochsPrescribed
-      : 1;
+    const observerRewardRatioWeight =
+      (1 + totalEpochsSubmitted) / (1 + totalEpochsPrescribed);
 
     // calculate composite weight based on sub weights
     const compositeWeight =

--- a/src/observers.ts
+++ b/src/observers.ts
@@ -211,7 +211,7 @@ export async function getPrescribedObserversForEpoch({
   }
 
   // return all the observers if there are fewer than the number of observers per epoch
-  if (MAXIMUM_OBSERVERS_PER_EPOCH >= Object.keys(weightedObservers).length) {
+  if (MAXIMUM_OBSERVERS_PER_EPOCH >= weightedObservers.length) {
     return weightedObservers;
   }
 

--- a/src/observers.ts
+++ b/src/observers.ts
@@ -194,7 +194,7 @@ export async function getPrescribedObserversForEpoch({
       gatewayRewardRatioWeight *
       observerRewardRatioWeight;
 
-    // remove any observers that have a 0 composite weight - they will cause an infinite loop when selecting observers, this may result in fewer observers than the maximum
+    // this should never happen - but necessary to avoid any potential infinite loops when prescribing gateways below
     if (compositeWeight === 0) continue;
 
     weightedObservers.push({


### PR DESCRIPTION
### Details
If either the gatewayRatioWeight or observerRatioWeight are 0 - the composite weight is 0. This then leads to an infinite loop when randomly assigning observers using those composite weights, bricking the contract 😢 . The solution is to increment both the numerator and denominator by 1 to ensure the ratios are never 0.