### PR TITLE
fix(observations): cleanup the implementation of saveObservations, add tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   clearMocks: true,
   moduleFileExtensions: ['ts', 'js', 'mjs'],
+  setupFilesAfterEnv: ['./tests/mocks.jest.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!**/node_modules/**',

--- a/schemas/saveObservations.js
+++ b/schemas/saveObservations.js
@@ -11,12 +11,6 @@ const saveObservationsSchema = {
       pattern: '^[a-zA-Z0-9-_]{43}$',
       description: 'The transaction ID of the submitted report',
     },
-    gatewayAddress: {
-      type: 'string',
-      pattern: '^[a-zA-Z0-9-_]{43}$',
-      description:
-        'The gateway address that sent the observation. If not provided, the caller address will be used.',
-    },
     failedGateways: {
       type: 'array',
       items: {

--- a/src/actions/read/gateways.test.ts
+++ b/src/actions/read/gateways.test.ts
@@ -1,7 +1,7 @@
 import { TENURE_WEIGHT_TOTAL_BLOCK_COUNT } from '../../constants';
 import { getBaselineState } from '../../tests/stubs';
 import { baselineGatewayData } from '../write/saveObservations.test';
-import { getGateway } from './gateways';
+import { getGateway, getGateways } from './gateways';
 
 describe('getGateway', () => {
   afterEach(() => {
@@ -119,5 +119,55 @@ describe('getGateway', () => {
         },
       },
     });
+  });
+});
+
+describe('getGateways', () => {
+  it('should return all the gateways and their weights', async () => {
+    const state = {
+      ...getBaselineState(),
+      gateways: {
+        'a-test-gateway': {
+          ...baselineGatewayData,
+          observerWallet: 'a-test-gateway',
+        },
+        'a-test-gateway-2': {
+          ...baselineGatewayData,
+          observerWallet: 'a-test-gateway-2',
+          start: 10,
+        },
+      },
+      // no distributions
+    };
+    const { result: gateways } = await getGateways(state);
+    expect(gateways).toEqual(
+      expect.objectContaining({
+        'a-test-gateway': {
+          ...baselineGatewayData,
+          observerWallet: 'a-test-gateway',
+          weights: {
+            stakeWeight: 1,
+            tenureWeight: 1 / TENURE_WEIGHT_TOTAL_BLOCK_COUNT, // started at the same block height
+            gatewayRewardRatioWeight: 1,
+            observerRewardRatioWeight: 1,
+            compositeWeight: 1 / TENURE_WEIGHT_TOTAL_BLOCK_COUNT,
+            normalizedCompositeWeight: 1,
+          },
+        },
+        'a-test-gateway-2': {
+          ...baselineGatewayData,
+          observerWallet: 'a-test-gateway-2',
+          start: 10,
+          weights: {
+            stakeWeight: 1,
+            tenureWeight: 0,
+            gatewayRewardRatioWeight: 1,
+            observerRewardRatioWeight: 1,
+            compositeWeight: 0,
+            normalizedCompositeWeight: 0,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/actions/read/observers.test.ts
+++ b/src/actions/read/observers.test.ts
@@ -1,6 +1,11 @@
+import {
+  DEFAULT_EPOCH_BLOCK_LENGTH,
+  TALLY_PERIOD_BLOCKS,
+  TENURE_WEIGHT_TOTAL_BLOCK_COUNT,
+} from '../../constants';
 import { getBaselineState } from '../../tests/stubs';
 import { baselineGatewayData } from '../write/saveObservations.test';
-import { getPrescribedObservers } from './observers';
+import { getEpoch, getPrescribedObservers } from './observers';
 
 describe('getPrescribedObservers', () => {
   it('should return the prescribed observers for the current epoch', async () => {
@@ -14,7 +19,7 @@ describe('getPrescribedObservers', () => {
     const { result } = await getPrescribedObservers(state);
     expect(result).toEqual([
       {
-        compositeWeight: 0.00000771604938271605,
+        compositeWeight: 1 / TENURE_WEIGHT_TOTAL_BLOCK_COUNT, // gateway started at the same block as the epoch, so it gets the default value
         gatewayAddress: 'a-test-gateway',
         gatewayRewardRatioWeight: 1,
         normalizedCompositeWeight: 1,
@@ -23,8 +28,55 @@ describe('getPrescribedObservers', () => {
         stake: 10000,
         stakeWeight: 1,
         start: 0,
-        tenureWeight: 0.00000771604938271605,
+        tenureWeight: 1 / TENURE_WEIGHT_TOTAL_BLOCK_COUNT, // gateway started at the same block as the epoch, so it gets the default value
       },
     ]);
+  });
+});
+
+describe('getEpoch', () => {
+  const state = getBaselineState();
+
+  it.each([
+    'not-a-number',
+    +SmartWeave.block.height + 1,
+    +state.distributions.epochZeroStartHeight - 1,
+  ])(
+    'should throw an error when the height is less than epochZeroStartHeight',
+    async (invalidHeight: number) => {
+      const error = await getEpoch(state, {
+        input: { height: invalidHeight },
+      }).catch((e) => e);
+      expect(error).toBeInstanceOf(ContractError);
+      expect(error.message).toEqual(
+        'Invalid height. Must be a number less than or equal to the current block height and greater than or equal to the epoch zero start height',
+      );
+    },
+  );
+
+  it('should return the epoch start and end heights when the height is valid', async () => {
+    const { result } = await getEpoch(state, {
+      input: { height: +SmartWeave.block.height },
+    });
+    expect(result).toEqual({
+      epochStartHeight: 0,
+      epochEndHeight: DEFAULT_EPOCH_BLOCK_LENGTH - 1,
+      epochDistributionHeight:
+        DEFAULT_EPOCH_BLOCK_LENGTH + TALLY_PERIOD_BLOCKS - 1,
+      epochZeroStartHeight: state.distributions.epochZeroStartHeight,
+      epochBlockLength: DEFAULT_EPOCH_BLOCK_LENGTH,
+    });
+  });
+
+  it('should return the epoch start and end heights when the height is not provided', async () => {
+    const { result } = await getEpoch(state, { input: { height: undefined } });
+    expect(result).toEqual({
+      epochStartHeight: 0,
+      epochEndHeight: DEFAULT_EPOCH_BLOCK_LENGTH - 1,
+      epochDistributionHeight:
+        DEFAULT_EPOCH_BLOCK_LENGTH + TALLY_PERIOD_BLOCKS - 1,
+      epochZeroStartHeight: state.distributions.epochZeroStartHeight,
+      epochBlockLength: DEFAULT_EPOCH_BLOCK_LENGTH,
+    });
   });
 });

--- a/src/actions/read/observers.test.ts
+++ b/src/actions/read/observers.test.ts
@@ -1,16 +1,9 @@
-import { getPrescribedObserversForEpoch } from '../../observers';
 import { getBaselineState } from '../../tests/stubs';
 import { baselineGatewayData } from '../write/saveObservations.test';
 import { getPrescribedObservers } from './observers';
 
-jest.mock('../../observers', () => ({
-  ...jest.requireActual('../../observers'),
-  getPrescribedObserversForEpoch: jest.fn().mockResolvedValue([]),
-}));
-
 describe('getPrescribedObservers', () => {
   it('should return the prescribed observers for the current epoch', async () => {
-    (getPrescribedObserversForEpoch as jest.Mock).mockResolvedValue([]);
     const state = {
       ...getBaselineState(),
       gateways: {
@@ -19,6 +12,19 @@ describe('getPrescribedObservers', () => {
       // no distributions
     };
     const { result } = await getPrescribedObservers(state);
-    expect(result).toEqual([]);
+    expect(result).toEqual([
+      {
+        compositeWeight: 0.00000771604938271605,
+        gatewayAddress: 'a-test-gateway',
+        gatewayRewardRatioWeight: 1,
+        normalizedCompositeWeight: 1,
+        observerAddress: 'fake-observer-wallet',
+        observerRewardRatioWeight: 1,
+        stake: 10000,
+        stakeWeight: 1,
+        start: 0,
+        tenureWeight: 0.00000771604938271605,
+      },
+    ]);
   });
 });

--- a/src/actions/read/observers.ts
+++ b/src/actions/read/observers.ts
@@ -45,7 +45,7 @@ export async function getEpoch(
     height > +SmartWeave.block.height
   ) {
     throw new ContractError(
-      'Invalid height. Must be a number less than or equal to the current block height',
+      'Invalid height. Must be a number less than or equal to the current block height and greater than or equal to the epoch zero start height',
     );
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,8 +45,6 @@ export const INVALID_OBSERVER_DOES_NOT_EXIST_MESSAGE =
   'Invalid caller. Observer does not exist as an observer address in the gateway registry.';
 export const INVALID_OBSERVATION_CALLER_MESSAGE =
   'Invalid caller. Caller is not eligible to submit observation reports for this epoch.';
-export const INVALID_OBSERVATION_FOR_GATEWAY_MESSAGE =
-  'Invalid CALLER. Caller is not the observer wallet for this gateway.';
 export const INVALID_GATEWAY_STAKE_AMOUNT_MESSAGE = `Quantity must be greater than or equal to the minimum network join stake amount.`;
 export const INVALID_OBSERVER_WALLET =
   'Invalid observer wallet. The provided observer wallet is correlated with another gateway.';

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -301,6 +301,17 @@ describe('isGatewayEligibleForDistribution', () => {
       true,
     ],
     [
+      'should be true if the gateway is joined, and started at the same block as the epoch start',
+      {
+        ...baselineGatewayData,
+        status: 'joined',
+        start: 10,
+      },
+      10,
+      Number.MAX_SAFE_INTEGER,
+      true,
+    ],
+    [
       'should be true if the gateway is leaving, but started before the epoch start and leaving after the end of the epoch',
       {
         ...baselineGatewayData,
@@ -353,12 +364,12 @@ describe('isGatewayEligibleForDistribution', () => {
       false,
     ],
     [
-      'should be false if gateway is joined and started the same block as the epoch start',
+      'should be false if gateway is joined and started after the epoch start',
       {
         ...baselineGatewayData,
         start: Number.MAX_SAFE_INTEGER,
       },
-      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER - 10,
       Number.MAX_SAFE_INTEGER,
       false,
     ],

--- a/tests/observation.test.ts
+++ b/tests/observation.test.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_START_HEIGHT,
   EXAMPLE_OBSERVER_REPORT_TX_IDS,
   INVALID_OBSERVATION_CALLER_MESSAGE,
-  INVALID_OBSERVER_DOES_NOT_EXIST_MESSAGE,
   WALLETS_TO_CREATE,
 } from './utils/constants';
 import {
@@ -301,7 +300,7 @@ describe('Observation', () => {
         expect(newCachedValue.state).toEqual(prevCachedValue.state);
       });
 
-      it('should not save observation report if the gateway is not in the registry and not observer', async () => {
+      it('should not save observation report if the caller is not a registered observer', async () => {
         const notJoinedGateway = await createLocalWallet(arweave);
         const { cachedValue: prevCachedValue } = await contract.readState();
         contract = warp.pst(srcContractId).connect(notJoinedGateway.wallet);
@@ -314,7 +313,7 @@ describe('Observation', () => {
         const { cachedValue: newCachedValue } = await contract.readState();
         expect(
           newCachedValue.errorMessages[writeInteraction?.originalTxId],
-        ).toEqual(INVALID_OBSERVER_DOES_NOT_EXIST_MESSAGE);
+        ).toEqual(INVALID_OBSERVATION_CALLER_MESSAGE);
         expect(newCachedValue.state).toEqual(prevCachedValue.state);
       });
     });


### PR DESCRIPTION
Observer wallets must now be unique, so you can not associate a single observer with multiple gateways. Reverting the changes that allowed an observer to submit observations for multiple gateways.

Adds additional unit tests for other read interactions.