### PR TITLE
chore(PE-5493): remove cruft, organize `constants.ts` and imports

### DIFF
--- a/src/actions/read/auctions.test.ts
+++ b/src/actions/read/auctions.test.ts
@@ -1,6 +1,6 @@
 import { baselineAuctionData, getBaselineState } from '../../tests/stubs';
 import { IOState } from '../../types';
-import { getAuction } from './auction';
+import { getAuction } from './auctions';
 
 describe('getAuction', () => {
   const stubbedBlockHeight = 50;

--- a/src/actions/read/auctions.ts
+++ b/src/actions/read/auctions.ts
@@ -2,6 +2,8 @@ import {
   calculateAuctionPriceForBlock,
   createAuctionObject,
   getAuctionPricesForInterval,
+  isNameAvailableForAuction,
+  isNameRequiredToBeAuction,
 } from '../../auctions';
 import {
   BlockHeight,
@@ -11,10 +13,6 @@ import {
   IOState,
   PstAction,
 } from '../../types';
-import {
-  isNameAvailableForAuction,
-  isNameRequiredToBeAuction,
-} from '../../utilities';
 
 export const getAuction = (
   state: DeepReadonly<IOState>,

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -8,6 +8,7 @@ import {
   calculateRegistrationFee,
   calculateUndernameCost,
 } from '../../pricing';
+import { assertAvailableRecord, isLeaseRecord } from '../../records';
 import {
   BlockHeight,
   BlockTimestamp,
@@ -15,11 +16,7 @@ import {
   DeepReadonly,
   IOState,
 } from '../../types';
-import {
-  assertAvailableRecord,
-  calculateYearsBetweenTimestamps,
-  isLeaseRecord,
-} from '../../utilities';
+import { calculateYearsBetweenTimestamps } from '../../utilities';
 import { BuyRecord } from '../write/buyRecord';
 import { ExtendRecord, assertRecordCanBeExtended } from '../write/extendRecord';
 import {

--- a/src/actions/write/buyRecord.ts
+++ b/src/actions/write/buyRecord.ts
@@ -1,3 +1,4 @@
+import { isNameRequiredToBeAuction } from '../../auctions';
 import {
   ARNS_NAME_IN_AUCTION_MESSAGE,
   ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE,
@@ -6,6 +7,7 @@ import {
   SECONDS_IN_A_YEAR,
 } from '../../constants';
 import { calculateRegistrationFee, tallyNamePurchase } from '../../pricing';
+import { assertAvailableRecord } from '../../records';
 import { safeTransfer } from '../../transfer';
 import {
   BlockTimestamp,
@@ -15,9 +17,7 @@ import {
   RegistrationType,
 } from '../../types';
 import {
-  assertAvailableRecord,
   getInvalidAjvMessage,
-  isNameRequiredToBeAuction,
   walletHasSufficientBalance,
 } from '../../utilities';
 // composed by ajv at build

--- a/src/actions/write/createVault.test.ts
+++ b/src/actions/write/createVault.test.ts
@@ -1,8 +1,8 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_INPUT_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from '../../constants';
 import { getBaselineState } from '../../tests/stubs';
 import { createVault } from './createVault';
@@ -33,8 +33,8 @@ describe('createVault', () => {
         '0',
         0,
         -1,
-        MIN_TOKEN_LOCK_LENGTH - 1,
-        MAX_TOKEN_LOCK_LENGTH + 1,
+        MIN_TOKEN_LOCK_BLOCK_LENGTH - 1,
+        MAX_TOKEN_LOCK_BLOCK_LENGTH + 1,
         Number.MAX_SAFE_INTEGER,
       ],
     ])(
@@ -66,7 +66,7 @@ describe('createVault', () => {
         caller: 'test',
         input: {
           qty: 100,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       }).catch((e) => e);
       expect(error).toBeInstanceOf(Error);
@@ -86,7 +86,7 @@ describe('createVault', () => {
         caller: 'test',
         input: {
           qty: 100,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       });
       expect(state).toEqual({
@@ -95,7 +95,7 @@ describe('createVault', () => {
           test: {
             [SmartWeave.transaction.id]: {
               balance: 100,
-              end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+              end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
               start: SmartWeave.block.height,
             },
           },

--- a/src/actions/write/extendRecord.ts
+++ b/src/actions/write/extendRecord.ts
@@ -1,11 +1,16 @@
 import {
+  ARNS_INVALID_EXTENSION_MESSAGE,
+  ARNS_INVALID_YEARS_MESSAGE,
   ARNS_NAME_DOES_NOT_EXIST_MESSAGE,
   INSUFFICIENT_FUNDS_MESSAGE,
-  INVALID_NAME_EXTENSION_TYPE_MESSAGE,
-  INVALID_YEARS_MESSAGE,
   SECONDS_IN_A_YEAR,
 } from '../../constants';
 import { calculateAnnualRenewalFee, tallyNamePurchase } from '../../pricing';
+import {
+  getMaxAllowedYearsExtensionForRecord,
+  isExistingActiveRecord,
+  isLeaseRecord,
+} from '../../records';
 import { safeTransfer } from '../../transfer';
 import {
   ArNSNameData,
@@ -16,9 +21,6 @@ import {
 } from '../../types';
 import {
   getInvalidAjvMessage,
-  getMaxAllowedYearsExtensionForRecord,
-  isExistingActiveRecord,
-  isLeaseRecord,
   walletHasSufficientBalance,
 } from '../../utilities';
 import { validateExtendRecord } from '../../validations';
@@ -70,7 +72,7 @@ export const extendRecord = async (
   }
 
   if (!isLeaseRecord(record)) {
-    throw new ContractError(INVALID_NAME_EXTENSION_TYPE_MESSAGE);
+    throw new ContractError(ARNS_INVALID_EXTENSION_MESSAGE);
   }
 
   assertRecordCanBeExtended({
@@ -130,13 +132,13 @@ export function assertRecordCanBeExtended({
   }
 
   if (!isLeaseRecord(record)) {
-    throw new ContractError(INVALID_NAME_EXTENSION_TYPE_MESSAGE);
+    throw new ContractError(ARNS_INVALID_EXTENSION_MESSAGE);
   }
 
   if (
     years >
     getMaxAllowedYearsExtensionForRecord({ currentBlockTimestamp, record })
   ) {
-    throw new ContractError(INVALID_YEARS_MESSAGE);
+    throw new ContractError(ARNS_INVALID_YEARS_MESSAGE);
   }
 }

--- a/src/actions/write/extendVault.test.ts
+++ b/src/actions/write/extendVault.test.ts
@@ -1,4 +1,7 @@
-import { INVALID_INPUT_MESSAGE, MIN_TOKEN_LOCK_LENGTH } from '../../constants';
+import {
+  INVALID_INPUT_MESSAGE,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
+} from '../../constants';
 import { getBaselineState, stubbedArweaveTxId } from '../../tests/stubs';
 import { IOState } from '../../types';
 import { extendVault } from './extendVault';
@@ -16,7 +19,7 @@ describe('extendVault', () => {
             test: {
               [stubbedArweaveTxId]: {
                 balance: 100,
-                end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+                end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
                 start: SmartWeave.block.height,
               },
             },
@@ -42,7 +45,7 @@ describe('extendVault', () => {
         caller: 'no-vault',
         input: {
           id: stubbedArweaveTxId,
-          extendLength: MIN_TOKEN_LOCK_LENGTH,
+          extendLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       }).catch((e) => e);
       expect(error).toBeInstanceOf(Error);
@@ -61,7 +64,7 @@ describe('extendVault', () => {
           test: {
             [stubbedArweaveTxId]: {
               balance: 100,
-              end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+              end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
               start: SmartWeave.block.height,
             },
           },
@@ -71,7 +74,7 @@ describe('extendVault', () => {
         caller: 'test',
         input: {
           id: stubbedArweaveTxId.replace('a', 'b'),
-          extendLength: MIN_TOKEN_LOCK_LENGTH,
+          extendLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       }).catch((e) => e);
       expect(error).toBeInstanceOf(Error);
@@ -87,14 +90,14 @@ describe('extendVault', () => {
           test: {
             [stubbedArweaveTxId]: {
               balance: 100,
-              end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+              end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
               start: SmartWeave.block.height,
             },
           },
         },
       };
       // TODO: should we allow extending a vault by 1 block if it already exists?
-      const extensionLength = MIN_TOKEN_LOCK_LENGTH;
+      const extensionLength = MIN_TOKEN_LOCK_BLOCK_LENGTH;
       const { state } = await extendVault(initialState, {
         caller: 'test',
         input: {
@@ -110,7 +113,7 @@ describe('extendVault', () => {
               balance: 100,
               end:
                 SmartWeave.block.height +
-                MIN_TOKEN_LOCK_LENGTH +
+                MIN_TOKEN_LOCK_BLOCK_LENGTH +
                 extensionLength,
               start: SmartWeave.block.height,
             },

--- a/src/actions/write/increaseUndernameCount.ts
+++ b/src/actions/write/increaseUndernameCount.ts
@@ -1,11 +1,12 @@
 import {
+  ARNS_MAX_UNDERNAME_MESSAGE,
   ARNS_NAME_DOES_NOT_EXIST_MESSAGE,
   INSUFFICIENT_FUNDS_MESSAGE,
   MAX_ALLOWED_UNDERNAMES,
-  MAX_UNDERNAME_MESSAGE,
   PERMABUY_LEASE_FEE_LENGTH,
 } from '../../constants';
 import { calculateUndernameCost } from '../../pricing';
+import { isExistingActiveRecord, isLeaseRecord } from '../../records';
 import { safeTransfer } from '../../transfer';
 import {
   ArNSNameData,
@@ -17,8 +18,6 @@ import {
 import {
   calculateYearsBetweenTimestamps,
   getInvalidAjvMessage,
-  isExistingActiveRecord,
-  isLeaseRecord,
   walletHasSufficientBalance,
 } from '../../utilities';
 import { validateIncreaseUndernameCount } from '../../validations';
@@ -129,6 +128,6 @@ export function assertRecordCanIncreaseUndernameCount({
 
   // the new total qty
   if (record.undernames + qty > MAX_ALLOWED_UNDERNAMES) {
-    throw new ContractError(MAX_UNDERNAME_MESSAGE);
+    throw new ContractError(ARNS_MAX_UNDERNAME_MESSAGE);
   }
 }

--- a/src/actions/write/increaseVault.test.ts
+++ b/src/actions/write/increaseVault.test.ts
@@ -1,7 +1,7 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_INPUT_MESSAGE,
-  MIN_TOKEN_LOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from '../../constants';
 import { getBaselineState, stubbedArweaveTxId } from '../../tests/stubs';
 import { IOState } from '../../types';
@@ -17,7 +17,7 @@ describe('increaseVault', () => {
           test: {
             'existing-vault-id': {
               balance: 100,
-              end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+              end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
               start: SmartWeave.block.height,
             },
           },
@@ -65,7 +65,7 @@ describe('increaseVault', () => {
         test: {
           [stubbedArweaveTxId]: {
             balance: 100,
-            end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+            end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
             start: SmartWeave.block.height,
           },
         },
@@ -92,7 +92,7 @@ describe('increaseVault', () => {
         test: {
           [stubbedArweaveTxId]: {
             balance: 100,
-            end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+            end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
             start: SmartWeave.block.height,
           },
         },
@@ -114,7 +114,7 @@ describe('increaseVault', () => {
         test: {
           [stubbedArweaveTxId]: {
             balance: 150,
-            end: SmartWeave.block.height + MIN_TOKEN_LOCK_LENGTH,
+            end: SmartWeave.block.height + MIN_TOKEN_LOCK_BLOCK_LENGTH,
             start: SmartWeave.block.height,
           },
         },

--- a/src/actions/write/submitAuctionBid.test.ts
+++ b/src/actions/write/submitAuctionBid.test.ts
@@ -1,8 +1,8 @@
 import { submitAuctionBid } from '../../actions/write/submitAuctionBid';
 import {
+  ARNS_LEASE_LENGTH_MAX_YEARS,
   ARNS_NAME_AUCTION_EXPIRED_MESSAGE,
   INSUFFICIENT_FUNDS_MESSAGE,
-  MAX_YEARS,
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
 } from '../../constants';
@@ -51,7 +51,7 @@ describe('submitAuctionBid', () => {
         name: 'valid-name',
         contractTxId: RESERVED_ATOMIC_TX_ID,
         type: 'lease',
-        years: MAX_YEARS + 1,
+        years: ARNS_LEASE_LENGTH_MAX_YEARS + 1,
       },
     ],
     [

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -1,5 +1,6 @@
 import {
   calculateAuctionPriceForBlock,
+  calculateExistingAuctionBidForCaller,
   createAuctionObject,
   getEndTimestampForAuction,
 } from '../../auctions';
@@ -10,6 +11,7 @@ import {
   RESERVED_ATOMIC_TX_ID,
 } from '../../constants';
 import { tallyNamePurchase } from '../../pricing';
+import { assertAvailableRecord } from '../../records';
 import {
   ArNSAuctionData,
   AuctionSettings,
@@ -24,8 +26,6 @@ import {
   RegistrationType,
 } from '../../types';
 import {
-  assertAvailableRecord,
-  calculateExistingAuctionBidForCaller,
   getInvalidAjvMessage,
   incrementBalance,
   unsafeDecrementBalance,

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -17,6 +17,7 @@ import {
   tallyNamePurchase,
   updateDemandFactor,
 } from '../../pricing';
+import { isActiveReservedName, isExistingActiveRecord } from '../../records';
 import { safeTransfer } from '../../transfer';
 import {
   Auctions,
@@ -43,8 +44,6 @@ import {
 } from '../../types';
 import {
   incrementBalance,
-  isActiveReservedName,
-  isExistingActiveRecord,
   isGatewayEligibleToBeRemoved,
 } from '../../utilities';
 

--- a/src/actions/write/vaultedTransfer.test.ts
+++ b/src/actions/write/vaultedTransfer.test.ts
@@ -1,7 +1,7 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_INPUT_MESSAGE,
-  MIN_TOKEN_LOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from '../../constants';
 import { getBaselineState, stubbedArweaveTxId } from '../../tests/stubs';
 import { vaultedTransfer } from './vaultedTransfer';
@@ -17,7 +17,7 @@ describe('vaultedTransfer', () => {
           input: {
             qty: badQty,
             target: 'new-wallet',
-            lockLength: MIN_TOKEN_LOCK_LENGTH,
+            lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
           },
         }).catch((e: any) => e);
         expect(error).toBeInstanceOf(Error);
@@ -36,7 +36,7 @@ describe('vaultedTransfer', () => {
           input: {
             qty: 100,
             target: badTarget,
-            lockLength: MIN_TOKEN_LOCK_LENGTH,
+            lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
           },
         }).catch((e: any) => e);
         expect(error).toBeInstanceOf(Error);
@@ -58,7 +58,7 @@ describe('vaultedTransfer', () => {
         input: {
           qty: 100,
           target: stubbedArweaveTxId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       }).catch((e: any) => e);
       expect(error).toBeInstanceOf(Error);
@@ -79,7 +79,7 @@ describe('vaultedTransfer', () => {
         input: {
           qty: 100,
           target: stubbedArweaveTxId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       });
       expect(state).toEqual({
@@ -92,7 +92,7 @@ describe('vaultedTransfer', () => {
             [SmartWeave.transaction.id]: {
               balance: 100,
               start: 1,
-              end: MIN_TOKEN_LOCK_LENGTH + 1,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH + 1,
             },
           },
         },
@@ -110,7 +110,7 @@ describe('vaultedTransfer', () => {
             'existing-vault-id': {
               balance: 10,
               start: 0,
-              end: MIN_TOKEN_LOCK_LENGTH,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
             },
           },
         },
@@ -120,7 +120,7 @@ describe('vaultedTransfer', () => {
         input: {
           qty: 100,
           target: stubbedArweaveTxId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       });
       expect(state).toEqual({
@@ -133,14 +133,14 @@ describe('vaultedTransfer', () => {
             [SmartWeave.transaction.id]: {
               balance: 100,
               start: 1,
-              end: MIN_TOKEN_LOCK_LENGTH + 1,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH + 1,
             },
           },
           test: {
             'existing-vault-id': {
               balance: 10,
               start: 0,
-              end: MIN_TOKEN_LOCK_LENGTH,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
             },
           },
         },
@@ -159,7 +159,7 @@ describe('vaultedTransfer', () => {
         input: {
           qty: 100,
           target: stubbedArweaveTxId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       });
       expect(state).toEqual({
@@ -172,7 +172,7 @@ describe('vaultedTransfer', () => {
             [SmartWeave.transaction.id]: {
               balance: 100,
               start: 1,
-              end: MIN_TOKEN_LOCK_LENGTH + 1,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH + 1,
             },
           },
         },
@@ -190,7 +190,7 @@ describe('vaultedTransfer', () => {
             'existing-vault-id': {
               balance: 10,
               start: 0,
-              end: MIN_TOKEN_LOCK_LENGTH,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
             },
           },
         },
@@ -200,7 +200,7 @@ describe('vaultedTransfer', () => {
         input: {
           qty: 100,
           target: stubbedArweaveTxId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         },
       });
       expect(state).toEqual({
@@ -213,12 +213,12 @@ describe('vaultedTransfer', () => {
             [SmartWeave.transaction.id]: {
               balance: 100,
               start: 1,
-              end: MIN_TOKEN_LOCK_LENGTH + 1,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH + 1,
             },
             'existing-vault-id': {
               balance: 10,
               start: 0,
-              end: MIN_TOKEN_LOCK_LENGTH,
+              end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
             },
           },
         },

--- a/src/auctions.test.ts
+++ b/src/auctions.test.ts
@@ -1,10 +1,17 @@
 import {
   calculateAuctionPriceForBlock,
+  calculateExistingAuctionBidForCaller,
   getAuctionPricesForInterval,
   getEndTimestampForAuction,
 } from './auctions';
 import { AUCTION_SETTINGS, SECONDS_IN_A_YEAR } from './constants';
-import { ArNSAuctionData, ArNSBaseAuctionData, BlockTimestamp } from './types';
+import {
+  ArNSAuctionData,
+  ArNSBaseAuctionData,
+  ArNSLeaseAuctionData,
+  BlockTimestamp,
+  IOToken,
+} from './types';
 import { BlockHeight } from './types';
 
 describe('calculateAuctionPriceForBlock', () => {
@@ -162,6 +169,39 @@ describe('calculateAuctionPriceForBlock', () => {
         });
         expect(endTimestamp).toEqual(expectedEndTimestamp);
       },
+    );
+  });
+});
+
+describe('calculateExistingAuctionBidForCaller function', () => {
+  const nihilisticAuction: ArNSLeaseAuctionData = {
+    startPrice: Number.NEGATIVE_INFINITY,
+    floorPrice: Number.NEGATIVE_INFINITY,
+    startHeight: Number.NEGATIVE_INFINITY,
+    endHeight: Number.NEGATIVE_INFINITY,
+    type: 'lease',
+    initiator: '',
+    contractTxId: '',
+    years: 1,
+    settings: {
+      auctionDuration: Number.NEGATIVE_INFINITY,
+      exponentialDecayRate: Number.NEGATIVE_INFINITY,
+      scalingExponent: Number.NEGATIVE_INFINITY,
+      floorPriceMultiplier: Number.NEGATIVE_INFINITY,
+      startPriceMultiplier: Number.NEGATIVE_INFINITY,
+    },
+  };
+
+  it('should throw if submitted bid is less than the required minimum bid', () => {
+    expect(() => {
+      calculateExistingAuctionBidForCaller({
+        caller: '',
+        auction: nihilisticAuction,
+        submittedBid: 1,
+        requiredMinimumBid: new IOToken(2),
+      });
+    }).toThrowError(
+      'The bid (1 IO) is less than the current required minimum bid of 2 IO.',
     );
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,31 +1,43 @@
-import { AuctionSettings } from './types';
+import { AuctionSettings, DemandFactoringSettings } from './types';
 
+/**
+ * BASE CONTROLS
+ */
 export const TOTAL_IO_SUPPLY = 1_000_000_000; // 1 billion IO tokens
 export const SECONDS_IN_A_YEAR = 31_536_000; // 52 weeks, 7 days per week, 24 hours per day, sixty minutes per hour, sixty seconds per minute
-export const MAX_YEARS = 5; // the maximum amount of years an arns name could be leased for
-export const MIN_YEARS = 1; // the minimum amount of years an arns name could be leased for
-export const NAMESPACE_LENGTH = 62; // browser domains are max 63 characters between periods, but we need to leave 1 character for the underscore seperator between the undernames and arns name
 export const MAX_ALLOWED_DECIMALS = 6; // the maximum allowed decimals for the IO Token
-export const MAX_NAME_LENGTH = 51; // the maximum length of an arns name - gateway sandbox domains are 52 characters, so to prevent overlap we stop 1 character short, where the 52nd character would be an underscore (which sandbox domains do not use) to prevent overlap
-export const MAX_NOTE_LENGTH = 256; // the maximum size of a note field
+export const BLOCKS_PER_DAY = 720;
+export const MIO_PER_IO = 1_000_000;
+export const ONE_MIO = 1 / MIO_PER_IO;
+
+/**
+ * GATEWAY REGISTRY CONTROLS
+ */
 export const MAX_GATEWAY_LABEL_LENGTH = 64; // the maximum size of a gateway label field used in the GAR
 export const MAX_PORT_NUMBER = 65535; // the default end port of tcp/udp port numbers
-export const TX_ID_LENGTH = 43; // the length of an arweave transaction id
-export const SECONDS_IN_GRACE_PERIOD = 1_814_400; // Three weeks, 7 days per week, 24 hours per day, sixty minutes per hour, sixty seconds per minute
-export const RESERVED_ATOMIC_TX_ID = 'atomic';
+export const GATEWAY_LEAVE_BLOCK_LENGTH = 90 * BLOCKS_PER_DAY; // 90 DAYS
+export const GATEWAY_REDUCE_STAKE_BLOCK_LENGTH = 30 * BLOCKS_PER_DAY; // 30 DAYS
+export const MAX_TOKEN_LOCK_BLOCK_LENGTH = 12 * 365 * BLOCKS_PER_DAY; // The maximum amount of blocks tokens can be locked in a vault (12 years of blocks)
+export const MIN_TOKEN_LOCK_BLOCK_LENGTH = 14 * BLOCKS_PER_DAY; // The minimum amount of blocks tokens can be locked in a vault (14 days of blocks)
+export const MINIMUM_ALLOWED_NAME_LENGTH = 5; // names less than 5 characters are reserved for auction
 export const NETWORK_JOIN_STATUS = 'joined';
 export const NETWORK_LEAVING_STATUS = 'leaving';
-export const SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP = 1725080400000; // August 31st, 2024
-export const GATEWAY_LEAVE_LENGTH = 3600; // 1 month
-export const BLOCKS_PER_DAY = 720;
-export const MAX_ALLOWED_EVOLUTION_DELAY = BLOCKS_PER_DAY * 30;
-export const MAX_TOKEN_LOCK_LENGTH = 12 * 365 * BLOCKS_PER_DAY; // The maximum amount of blocks tokens can be locked in a vault (12 years of blocks)
-export const MIN_TOKEN_LOCK_LENGTH = 14 * BLOCKS_PER_DAY; // The minimum amount of blocks tokens can be locked in a vault (14 days of blocks)
-export const MINIMUM_ALLOWED_EVOLUTION_DELAY = 3; // 3 blocks for testing purposes, but should be 720 * 7; // 720 blocks per day times 7 days
-export const MINIMUM_ALLOWED_NAME_LENGTH = 5; // names less than 5 characters are reserved for auction
+
+/**
+ * OBSERVER WEIGHTS
+ */
+export const MAX_TENURE_WEIGHT = 4; // 4 - 6 month periods mark you as a mature gateway
 export const TENURE_WEIGHT_DAYS = 180; // the amount of days in a single tenure weight period used to calculate composite weights for observation
 export const TENURE_WEIGHT_TOTAL_BLOCK_COUNT =
   TENURE_WEIGHT_DAYS * BLOCKS_PER_DAY; // the # of blocks in a single tenure weight period (6-months) used to calculate composite weights for observation
+
+/**
+ * ARNS CONTROLS
+ */
+export const ARNS_LEASE_LENGTH_MAX_YEARS = 5; // the maximum amount of years an arns name could be leased for
+export const ARNS_LEASE_LENGTH_MIN_YEARS = 1; // the minimum amount of years an arns name could be leased for
+export const RESERVED_ATOMIC_TX_ID = 'atomic';
+export const SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP = 1725080400000; // August 31st, 2024
 export const PERMABUY_LEASE_FEE_LENGTH = 10;
 export const ANNUAL_PERCENTAGE_FEE = 0.2; // 20% of cost of name
 export const DEFAULT_UNDERNAME_COUNT = 10;
@@ -33,14 +45,29 @@ export const UNDERNAME_LEASE_FEE_PERCENTAGE = 0.001; // .1% of cost of name
 export const UNDERNAME_PERMABUY_FEE_PERCENTAGE = 0.005; // .5% of cost of name
 export const MAX_ALLOWED_UNDERNAMES = 10_000; // when modifying these, update the undernames schema
 export const UNDERNAME_REGISTRATION_IO_FEE = 1; // 1 IO token per undername
+export const MAX_NAME_LENGTH = 51; // the maximum length of an arns name - gateway sandbox domains are 52 characters, so to prevent overlap we stop 1 character short, where the 52nd character would be an underscore (which sandbox domains do not use) to prevent overlap
+export const MAX_NOTE_LENGTH = 256; // the maximum size of a note field
+export const SECONDS_IN_GRACE_PERIOD = 1_814_400; // Three weeks, 7 days per week, 24 hours per day, sixty minutes per hour, sixty seconds per minute
+
+/**
+ * ERROR MESSAGES
+ */
 export const NON_CONTRACT_OWNER_MESSAGE = `Caller is not the owner of the ArNS!`;
-export const INVALID_ARNS_NAME_MESSAGE = 'Invalid ArNS Record Name';
+export const ARNS_INVALID_NAME_MESSAGE = 'Invalid ArNS Record Name';
 export const ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE = 'Name must be auctioned.';
 export const ARNS_NAME_RESERVED_MESSAGE = 'Name is reserved.';
 export const ARNS_NAME_IN_AUCTION_MESSAGE = 'Name is currently in auction.';
 export const ARNS_NAME_AUCTION_EXPIRED_MESSAGE = 'Auction has expired.';
-export const INVALID_INPUT_MESSAGE = 'Invalid input for interaction';
-export const INVALID_VAULT_LOCK_LENGTH_MESSAGE = `Invalid lock length. Must be between ${MIN_TOKEN_LOCK_LENGTH} - ${MAX_TOKEN_LOCK_LENGTH}.`;
+export const ARNS_NON_EXPIRED_NAME_MESSAGE =
+  'This name already exists in an active lease';
+export const ARNS_NAME_DOES_NOT_EXIST_MESSAGE =
+  'Name does not exist in the ArNS Contract!';
+export const ARNS_MAX_UNDERNAME_MESSAGE = `Name has reached undername limit of ${MAX_ALLOWED_UNDERNAMES}`;
+export const ARNS_INVALID_YEARS_MESSAGE = `Invalid number of years. Must be an integer and less than or equal to ${ARNS_LEASE_LENGTH_MAX_YEARS}`;
+export const ARNS_INVALID_SHORT_NAME = `Name is less than ${MINIMUM_ALLOWED_NAME_LENGTH} characters. It will be available for auction after ${SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP}.`;
+export const ARNS_INVALID_EXTENSION_MESSAGE = `This name has been permanently registered and its lease cannot be extended.`;
+
+export const INVALID_VAULT_LOCK_LENGTH_MESSAGE = `Invalid lock length. Must be between ${MIN_TOKEN_LOCK_BLOCK_LENGTH} - ${MAX_TOKEN_LOCK_BLOCK_LENGTH}.`;
 export const INVALID_OBSERVER_DOES_NOT_EXIST_MESSAGE =
   'Invalid caller. Observer does not exist as an observer address in the gateway registry.';
 export const INVALID_OBSERVATION_CALLER_MESSAGE =
@@ -54,32 +81,27 @@ export const INVALID_OBSERVATION_TARGET_MESSAGE =
   'Target gateway is leaving the network and must not be observed';
 export const INVALID_GATEWAY_EXISTS_MESSAGE =
   'A gateway with this address already exists.';
-export const DEFAULT_NUM_SAMPLED_BLOCKS = 3;
-export const DEFAULT_SAMPLED_BLOCKS_OFFSET = 50;
-export const DEFAULT_EPOCH_BLOCK_LENGTH = 200; // TODO: make this 5000 for testnet
-export const DEFAULT_START_HEIGHT = 0; // TODO: this should be coordinated with the genesis block height
+export const INSUFFICIENT_FUNDS_MESSAGE =
+  'Insufficient funds for this transaction.';
+export const INVALID_TARGET_MESSAGE = 'Invalid target specified';
+export const INVALID_QTY_MESSAGE =
+  'Invalid quantity. Must be an integer and greater than 0.';
+export const INVALID_INPUT_MESSAGE = 'Invalid input for interaction';
+
+/**
+ * OBSERVATION AND DISTRIBUTIONS
+ */
+export const DEFAULT_SAMPLED_BLOCKS_COUNT = 3; // the number of blocks we sample when calculating the base hash for prescribed observers
+export const DEFAULT_SAMPLED_BLOCKS_OFFSET = 50; // the number of blocks offset from the current epoch start height we sample when calculating the base hash for prescribed observers
+export const DEFAULT_EPOCH_BLOCK_LENGTH = 200; // TODO: make this 5000 for mainnet
 export const TALLY_PERIOD_BLOCKS = DEFAULT_EPOCH_BLOCK_LENGTH / 4; // TODO: set this to 100 for testnet
 export const EPOCH_REWARD_PERCENTAGE = 0.0025; // 0.25% of total available protocol balance
 export const GATEWAY_PERCENTAGE_OF_EPOCH_REWARD = 0.95;
 export const OBSERVATION_FAILURE_THRESHOLD = 0.51;
 export const BAD_OBSERVER_GATEWAY_PENALTY = 0.25;
 export const MAXIMUM_OBSERVERS_PER_EPOCH = 4; // TODO: set this to 50 for testnet
-export const NON_EXPIRED_ARNS_NAME_MESSAGE =
-  'This name already exists in an active lease';
-export const ARNS_NAME_DOES_NOT_EXIST_MESSAGE =
-  'Name does not exist in the ArNS Contract!';
-export const EXISTING_ANT_SOURCE_CODE_TX_MESSAGE =
-  'This ANT Source Code Transaction ID is already allowed.';
-export const INSUFFICIENT_FUNDS_MESSAGE =
-  'Insufficient funds for this transaction.';
-export const INVALID_TARGET_MESSAGE = 'Invalid target specified';
-export const INVALID_QTY_MESSAGE =
-  'Invalid quantity. Must be an integer and greater than 0.';
-export const INVALID_YEARS_MESSAGE = `Invalid number of years. Must be an integer and less than or equal to ${MAX_YEARS}`;
-export const INVALID_NAME_EXTENSION_TYPE_MESSAGE = `This name has been permanently registered and its lease cannot be extended.`;
-export const INVALID_SHORT_NAME = `Name is less than ${MINIMUM_ALLOWED_NAME_LENGTH} characters. It will be available for auction after ${SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP}.`;
-export const MAX_UNDERNAME_MESSAGE = `Name has reached undername limit of ${MAX_ALLOWED_UNDERNAMES}`;
-export const FEE_STRUCTURE = {
+// the initial fee structure for the genesis block of the contract
+export const GENESIS_FEES = {
   '1': 4218750000,
   '2': 1406250000,
   '3': 468750000,
@@ -132,6 +154,7 @@ export const FEE_STRUCTURE = {
   '50': 50,
   '51': 50,
 };
+// initial names reserved by the contract owner
 export const RESERVED_NAMES = [
   'arns',
   'ar-io',
@@ -149,6 +172,7 @@ export const RESERVED_NAMES = [
   'docs',
   'admin',
 ];
+// the auction settings applied to all auctions
 export const AUCTION_SETTINGS: AuctionSettings = {
   floorPriceMultiplier: 1,
   startPriceMultiplier: 50,
@@ -156,18 +180,7 @@ export const AUCTION_SETTINGS: AuctionSettings = {
   scalingExponent: 190,
   auctionDuration: 10_080, // approx 14 days long
 };
-export const MAX_TENURE_WEIGHT = 4; // 4 - 6 month periods mark you as a mature gateway
-export type DemandFactoringCriteria = 'purchases' | 'revenue';
-type DemandFactoringSettings = {
-  movingAvgPeriodCount: number;
-  periodBlockCount: number;
-  demandFactorBaseValue: number;
-  demandFactorMin: number;
-  demandFactorUpAdjustment: number;
-  demandFactorDownAdjustment: number;
-  stepDownThreshold: number;
-  criteria: DemandFactoringCriteria;
-};
+// the demand factoring settings used to determine when to step down - criteria specifies whether accounting is revenue or purchase count based
 export const DEMAND_FACTORING_SETTINGS: DemandFactoringSettings = {
   movingAvgPeriodCount: 7,
   periodBlockCount: 720,
@@ -178,6 +191,3 @@ export const DEMAND_FACTORING_SETTINGS: DemandFactoringSettings = {
   stepDownThreshold: 3, // number of times at minimum allowed before resetting genesis fees (ultimately leads to 4 periods at the new fee, including the reset period)
   criteria: 'revenue',
 };
-
-export const MIO_PER_IO = 1_000_000;
-export const ONE_MIO = 1 / MIO_PER_IO;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,6 +1,6 @@
 // ~~ Put all the interactions from '../actions/` together to write the final handle function which will be exported
 // from the contract source. ~~
-import { getAuction } from './actions/read/auction';
+import { getAuction } from './actions/read/auctions';
 import { balance } from './actions/read/balance';
 import { getGateway, getGateways } from './actions/read/gateways';
 import { getEpoch, getPrescribedObservers } from './actions/read/observers';

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 
 import {
   DEFAULT_EPOCH_BLOCK_LENGTH,
-  GATEWAY_LEAVE_LENGTH,
+  GATEWAY_LEAVE_BLOCK_LENGTH,
   MAXIMUM_OBSERVERS_PER_EPOCH,
   TALLY_PERIOD_BLOCKS,
   TENURE_WEIGHT_TOTAL_BLOCK_COUNT,
@@ -316,11 +316,11 @@ describe('isGatewayEligibleForDistribution', () => {
       {
         ...baselineGatewayData,
         status: 'leaving',
-        end: GATEWAY_LEAVE_LENGTH + 1,
+        end: GATEWAY_LEAVE_BLOCK_LENGTH + 1,
         start: 0,
       },
       10,
-      GATEWAY_LEAVE_LENGTH,
+      GATEWAY_LEAVE_BLOCK_LENGTH,
       true,
     ],
     [
@@ -357,10 +357,10 @@ describe('isGatewayEligibleForDistribution', () => {
         ...baselineGatewayData,
         status: 'leaving',
         start: 10,
-        end: GATEWAY_LEAVE_LENGTH - 1,
+        end: GATEWAY_LEAVE_BLOCK_LENGTH - 1,
       },
       10,
-      GATEWAY_LEAVE_LENGTH,
+      GATEWAY_LEAVE_BLOCK_LENGTH,
       false,
     ],
     [

--- a/src/observers.ts
+++ b/src/observers.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_EPOCH_BLOCK_LENGTH,
-  DEFAULT_NUM_SAMPLED_BLOCKS,
+  DEFAULT_SAMPLED_BLOCKS_COUNT,
   DEFAULT_SAMPLED_BLOCKS_OFFSET,
   MAXIMUM_OBSERVERS_PER_EPOCH,
   MAX_TENURE_WEIGHT,
@@ -53,7 +53,7 @@ export async function getEntropyHashForEpoch({
   let bufferHash: Buffer = Buffer.from('');
   // We hash multiple previous block hashes to reduce the chance that someone will
   // influence the value produced by grinding with excessive hash power.
-  for (let i = 0; i < DEFAULT_NUM_SAMPLED_BLOCKS; i++) {
+  for (let i = 0; i < DEFAULT_SAMPLED_BLOCKS_COUNT; i++) {
     const blockHeight = Math.max(
       0,
       epochStartHeight.valueOf() - DEFAULT_SAMPLED_BLOCKS_OFFSET - i,

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -1,4 +1,3 @@
-import { DemandFactoringCriteria } from './constants';
 import {
   cloneDemandFactoringData,
   demandFactorPeriodIndex,
@@ -10,7 +9,12 @@ import {
   tallyNamePurchase,
   updateDemandFactor,
 } from './pricing';
-import { BlockHeight, DemandFactoringData, Fees } from './types';
+import {
+  BlockHeight,
+  DemandFactoringCriteria,
+  DemandFactoringData,
+  Fees,
+} from './types';
 
 describe('Pricing functions:', () => {
   describe('periodAtHeight function', () => {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,7 +1,6 @@
 import {
   ANNUAL_PERCENTAGE_FEE,
   DEMAND_FACTORING_SETTINGS,
-  DemandFactoringCriteria,
   ONE_MIO,
   PERMABUY_LEASE_FEE_LENGTH,
   UNDERNAME_LEASE_FEE_PERCENTAGE,
@@ -12,6 +11,7 @@ import {
   BlockHeight,
   BlockTimestamp,
   DeepReadonly,
+  DemandFactoringCriteria,
   DemandFactoringData,
   Fees,
   IOState,

--- a/src/records.test.ts
+++ b/src/records.test.ts
@@ -1,0 +1,29 @@
+import { isLeaseRecord } from './records';
+import { ArNSBaseNameData, ArNSNameData } from './types';
+
+describe('isLeaseRecord function', () => {
+  const stubBaseNameData: ArNSBaseNameData = {
+    contractTxId: '',
+    startTimestamp: 0,
+    type: 'permabuy',
+    undernames: 0,
+    purchasePrice: 0,
+  };
+
+  it.each([
+    [stubBaseNameData, false],
+    [
+      {
+        ...stubBaseNameData,
+        type: 'lease',
+        endTimestamp: 1,
+      },
+      true,
+    ],
+  ])(
+    'should, for record %p, return %s',
+    (record: ArNSNameData, expectedValue: boolean) => {
+      expect(isLeaseRecord(record)).toEqual(expectedValue);
+    },
+  );
+});

--- a/src/records.ts
+++ b/src/records.ts
@@ -1,0 +1,167 @@
+import {
+  ARNS_INVALID_SHORT_NAME,
+  ARNS_LEASE_LENGTH_MAX_YEARS,
+  ARNS_NAME_RESERVED_MESSAGE,
+  ARNS_NON_EXPIRED_NAME_MESSAGE,
+  MINIMUM_ALLOWED_NAME_LENGTH,
+  SECONDS_IN_A_YEAR,
+  SECONDS_IN_GRACE_PERIOD,
+  SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
+} from './constants';
+import {
+  ArNSLeaseData,
+  ArNSNameData,
+  BlockTimestamp,
+  DeepReadonly,
+  Records,
+  ReservedNameData,
+  ReservedNames,
+} from './types';
+
+export function isNameInGracePeriod({
+  currentBlockTimestamp,
+  record,
+}: {
+  currentBlockTimestamp: BlockTimestamp;
+  record: ArNSLeaseData;
+}): boolean {
+  if (!record.endTimestamp) return false;
+  const recordIsExpired = currentBlockTimestamp.valueOf() > record.endTimestamp;
+  return (
+    recordIsExpired &&
+    record.endTimestamp + SECONDS_IN_GRACE_PERIOD >
+      currentBlockTimestamp.valueOf()
+  );
+}
+
+export function getMaxAllowedYearsExtensionForRecord({
+  currentBlockTimestamp,
+  record,
+}: {
+  currentBlockTimestamp: BlockTimestamp;
+  record: ArNSLeaseData;
+}): number {
+  if (!record.endTimestamp) {
+    return 0;
+  }
+  // if expired return 0 because it cannot be extended and must be re-bought
+  if (
+    currentBlockTimestamp.valueOf() >
+    record.endTimestamp + SECONDS_IN_GRACE_PERIOD
+  ) {
+    return 0;
+  }
+
+  if (isNameInGracePeriod({ currentBlockTimestamp, record })) {
+    return ARNS_LEASE_LENGTH_MAX_YEARS;
+  }
+
+  // TODO: should we put this as the ceiling? or should we allow people to extend as soon as it is purchased
+  const yearsRemainingOnLease = Math.ceil(
+    (record.endTimestamp.valueOf() - currentBlockTimestamp.valueOf()) /
+      SECONDS_IN_A_YEAR,
+  );
+
+  // a number between 0 and 5 (MAX_YEARS)
+  return ARNS_LEASE_LENGTH_MAX_YEARS - yearsRemainingOnLease;
+}
+
+export function isExistingActiveRecord({
+  record,
+  currentBlockTimestamp,
+}: {
+  record: ArNSNameData | undefined;
+  currentBlockTimestamp: BlockTimestamp;
+}): boolean {
+  if (!record) return false;
+
+  if (record.type === 'permabuy') {
+    return true;
+  }
+
+  if (record.type === 'lease' && record.endTimestamp) {
+    return (
+      record.endTimestamp > currentBlockTimestamp.valueOf() ||
+      isNameInGracePeriod({ currentBlockTimestamp, record })
+    );
+  }
+  return false;
+}
+
+export function isShortNameRestricted({
+  name,
+  currentBlockTimestamp,
+}: {
+  name: string;
+  currentBlockTimestamp: BlockTimestamp;
+}): boolean {
+  return (
+    name.length < MINIMUM_ALLOWED_NAME_LENGTH &&
+    currentBlockTimestamp.valueOf() < SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP
+  );
+}
+
+export function isActiveReservedName({
+  caller,
+  reservedName,
+  currentBlockTimestamp,
+}: {
+  caller: string | undefined;
+  reservedName: ReservedNameData | undefined;
+  currentBlockTimestamp: BlockTimestamp;
+}): boolean {
+  if (!reservedName) return false;
+  const target = reservedName.target;
+  const endTimestamp = reservedName.endTimestamp;
+  const permanentlyReserved = !target && !endTimestamp;
+  if (permanentlyReserved) {
+    return true;
+  }
+  const callerNotTarget = !caller || target !== caller;
+  const notExpired =
+    endTimestamp && endTimestamp > currentBlockTimestamp.valueOf();
+  if (callerNotTarget && notExpired) {
+    return true;
+  }
+  return false;
+}
+
+export function assertAvailableRecord({
+  caller,
+  name,
+  records,
+  reserved,
+  currentBlockTimestamp,
+}: {
+  caller: string | undefined; // TODO: type for this
+  name: DeepReadonly<string>;
+  records: DeepReadonly<Records>;
+  reserved: DeepReadonly<ReservedNames>;
+  currentBlockTimestamp: BlockTimestamp;
+}): void {
+  if (
+    isExistingActiveRecord({
+      record: records[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(ARNS_NON_EXPIRED_NAME_MESSAGE);
+  }
+  if (
+    isActiveReservedName({
+      caller,
+      reservedName: reserved[name],
+      currentBlockTimestamp,
+    })
+  ) {
+    throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
+  }
+
+  if (isShortNameRestricted({ name, currentBlockTimestamp })) {
+    throw new ContractError(ARNS_INVALID_SHORT_NAME);
+  }
+}
+
+export function isLeaseRecord(record: ArNSNameData): record is ArNSLeaseData {
+  return record.type === 'lease';
+}

--- a/src/tests/stubs.ts
+++ b/src/tests/stubs.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_EPOCH_BLOCK_LENGTH,
-  FEE_STRUCTURE,
+  GENESIS_FEES,
   TALLY_PERIOD_BLOCKS,
 } from '../constants';
 import {
@@ -49,9 +49,7 @@ export const getBaselineState: () => IOState = (): IOState => ({
     observers: {},
   },
   reserved: {},
-  fees: {
-    ...FEE_STRUCTURE,
-  },
+  fees: GENESIS_FEES,
   auctions: {},
   settings: {
     registry: {

--- a/src/transfer.test.ts
+++ b/src/transfer.test.ts
@@ -1,8 +1,8 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_VAULT_LOCK_LENGTH_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from './constants';
 import { safeTransfer, safeVaultedTransfer } from './transfer';
 import { BlockHeight, IOToken, RegistryVaults, VaultData } from './types';
@@ -104,7 +104,7 @@ describe('safeVaultedTransfer function', () => {
           fromAddress,
           id: 'new-vaulted-transfer',
           toAddress: 'biz',
-          lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+          lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
           startHeight: new BlockHeight(0),
         });
       }).toThrowError(INSUFFICIENT_FUNDS_MESSAGE);
@@ -120,13 +120,13 @@ describe('safeVaultedTransfer function', () => {
         fromAddress: 'foo',
         id: 'new-vaulted-transfer',
         toAddress: 'biz',
-        lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
         startHeight: new BlockHeight(0),
       });
     }).toThrowError(INSUFFICIENT_FUNDS_MESSAGE);
   });
 
-  it.each([0, MAX_TOKEN_LOCK_LENGTH + 1])(
+  it.each([0, MAX_TOKEN_LOCK_BLOCK_LENGTH + 1])(
     'should throw an error if lock length is invalid %s',
     (lockLength) => {
       expect(() => {
@@ -154,7 +154,7 @@ describe('safeVaultedTransfer function', () => {
     const expectedNewVaultData: VaultData = {
       balance: qty,
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeVaultedTransfer({
       balances,
@@ -163,7 +163,7 @@ describe('safeVaultedTransfer function', () => {
       fromAddress,
       id: 'new-vaulted-transfer',
       toAddress,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
     });
     expect(balances).toEqual({ foo: 1, bar: 2 });
@@ -189,7 +189,7 @@ describe('safeVaultedTransfer function', () => {
     const expectedNewVaultData: VaultData = {
       balance: qty,
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeVaultedTransfer({
       balances,
@@ -197,7 +197,7 @@ describe('safeVaultedTransfer function', () => {
       fromAddress,
       toAddress,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
       id: 'new-vaulted-transfer',
     });
@@ -219,14 +219,14 @@ describe('safeVaultedTransfer function', () => {
       fromAddress,
       toAddress,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
       id: 'new-vaulted-transfer',
     });
     const expectedNewVaultData: VaultData = {
       balance: qty,
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     expect(balances).toEqual({ bar: 2 });
     expect(vaults[toAddress]['new-vaulted-transfer']).toEqual(
@@ -246,14 +246,14 @@ describe('safeVaultedTransfer function', () => {
       fromAddress,
       toAddress,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
       id: 'new-vaulted-transfer',
     });
     const expectedNewVaultData: VaultData = {
       balance: qty,
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     expect(balances).toEqual({ foo: 1, bar: 2 });
     expect(vaults[toAddress]['new-vaulted-transfer']).toEqual(
@@ -281,7 +281,7 @@ describe('safeVaultedTransfer function', () => {
         fromAddress,
         toAddress,
         vaults,
-        lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
         startHeight: new BlockHeight(0),
         id: 'existing-vault-id',
       }),

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -2,8 +2,8 @@ import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_TARGET_MESSAGE,
   INVALID_VAULT_LOCK_LENGTH_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from './constants';
 import {
   Balances,
@@ -75,8 +75,8 @@ export function safeVaultedTransfer({
   }
 
   if (
-    lockLength.valueOf() < MIN_TOKEN_LOCK_LENGTH ||
-    lockLength.valueOf() > MAX_TOKEN_LOCK_LENGTH
+    lockLength.valueOf() < MIN_TOKEN_LOCK_BLOCK_LENGTH ||
+    lockLength.valueOf() > MAX_TOKEN_LOCK_BLOCK_LENGTH
   ) {
     throw new ContractError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,18 @@ export type GatewaySettings = {
   note?: string; // An additional note (256 character max) the gateway operator can set to indicate things like maintenance or other operational updates.
 };
 
+export type DemandFactoringCriteria = 'purchases' | 'revenue';
+export type DemandFactoringSettings = {
+  movingAvgPeriodCount: number;
+  periodBlockCount: number;
+  demandFactorBaseValue: number;
+  demandFactorMin: number;
+  demandFactorUpAdjustment: number;
+  demandFactorDownAdjustment: number;
+  stepDownThreshold: number;
+  criteria: DemandFactoringCriteria;
+};
+
 export type AllowedProtocols = 'http' | 'https';
 export type RegistrationType = 'lease' | 'permabuy';
 

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,59 +1,15 @@
 import { TOTAL_IO_SUPPLY } from './constants';
 import { getBaselineState } from './tests/stubs';
+import { BlockHeight, BlockTimestamp, GatewayStatus, IOState } from './types';
 import {
-  ArNSBaseNameData,
-  ArNSLeaseAuctionData,
-  ArNSNameData,
-  BlockHeight,
-  BlockTimestamp,
-  GatewayStatus,
-  IOState,
-  IOToken,
-} from './types';
-import {
-  calculateExistingAuctionBidForCaller,
   calculateYearsBetweenTimestamps,
   incrementBalance,
   isGatewayEligibleToBeRemoved,
   isGatewayEligibleToLeave,
   isGatewayJoined,
-  isLeaseRecord,
   resetProtocolBalance,
   unsafeDecrementBalance,
 } from './utilities';
-
-describe('calculateExistingAuctionBidForCaller function', () => {
-  const nihilisticAuction: ArNSLeaseAuctionData = {
-    startPrice: Number.NEGATIVE_INFINITY,
-    floorPrice: Number.NEGATIVE_INFINITY,
-    startHeight: Number.NEGATIVE_INFINITY,
-    endHeight: Number.NEGATIVE_INFINITY,
-    type: 'lease',
-    initiator: '',
-    contractTxId: '',
-    years: 1,
-    settings: {
-      auctionDuration: Number.NEGATIVE_INFINITY,
-      exponentialDecayRate: Number.NEGATIVE_INFINITY,
-      scalingExponent: Number.NEGATIVE_INFINITY,
-      floorPriceMultiplier: Number.NEGATIVE_INFINITY,
-      startPriceMultiplier: Number.NEGATIVE_INFINITY,
-    },
-  };
-
-  it('should throw if submitted bid is less than the required minimum bid', () => {
-    expect(() => {
-      calculateExistingAuctionBidForCaller({
-        caller: '',
-        auction: nihilisticAuction,
-        submittedBid: 1,
-        requiredMinimumBid: new IOToken(2),
-      });
-    }).toThrowError(
-      'The bid (1 IO) is less than the current required minimum bid of 2 IO.',
-    );
-  });
-});
 
 describe('isGatewayJoined function', () => {
   it('should return false if gateway is undefined', () => {
@@ -305,33 +261,6 @@ describe('incrementBalance function', () => {
     incrementBalance(balances, 'foo', 1);
     expect(balances).toEqual({ foo: 2, bar: 2 });
   });
-});
-
-describe('isLeaseRecord function', () => {
-  const stubBaseNameData: ArNSBaseNameData = {
-    contractTxId: '',
-    startTimestamp: 0,
-    type: 'permabuy',
-    undernames: 0,
-    purchasePrice: 0,
-  };
-
-  it.each([
-    [stubBaseNameData, false],
-    [
-      {
-        ...stubBaseNameData,
-        type: 'lease',
-        endTimestamp: 1,
-      },
-      true,
-    ],
-  ])(
-    'should, for record %p, return %s',
-    (record: ArNSNameData, expectedValue: boolean) => {
-      expect(isLeaseRecord(record)).toEqual(expectedValue);
-    },
-  );
 });
 
 describe('resetProtocolBalance function', () => {

--- a/src/vaults.test.ts
+++ b/src/vaults.test.ts
@@ -1,8 +1,8 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_VAULT_LOCK_LENGTH_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from './constants';
 import { BlockHeight, PositiveFiniteInteger, RegistryVaults } from './types';
 import { safeCreateVault, safeExtendVault, safeIncreaseVault } from './vaults';
@@ -22,7 +22,7 @@ describe('safeCreateVault function', () => {
           address: fromAddr,
           vaults: {},
           id: 'new-vault-id',
-          lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+          lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
           startHeight: new BlockHeight(0),
         });
       }).toThrowError(INSUFFICIENT_FUNDS_MESSAGE);
@@ -37,7 +37,7 @@ describe('safeCreateVault function', () => {
         address: 'foo',
         vaults: {},
         id: 'new-vault-id',
-        lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
         startHeight: new BlockHeight(0),
       });
     }).toThrowError('Insufficient funds for this transaction.');
@@ -59,29 +59,30 @@ describe('safeCreateVault function', () => {
           },
         },
         id: 'existing-vault-id',
-        lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
         startHeight: new BlockHeight(0),
       });
     }).toThrowError("Vault with id 'existing-vault-id' already exists");
   });
 
-  it.each([0, MIN_TOKEN_LOCK_LENGTH - 1, MAX_TOKEN_LOCK_LENGTH + 1])(
-    'should throw an error if lock length is invalid %s',
-    (lockLength) => {
-      expect(() => {
-        const balances = { foo: 2, bar: 2 };
-        safeCreateVault({
-          balances,
-          qty: new PositiveFiniteInteger(1),
-          address: 'foo',
-          vaults: {},
-          lockLength: new BlockHeight(lockLength),
-          id: 'new-vault-id',
-          startHeight: new BlockHeight(0),
-        });
-      }).toThrowError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
-    },
-  );
+  it.each([
+    0,
+    MIN_TOKEN_LOCK_BLOCK_LENGTH - 1,
+    MAX_TOKEN_LOCK_BLOCK_LENGTH + 1,
+  ])('should throw an error if lock length is invalid %s', (lockLength) => {
+    expect(() => {
+      const balances = { foo: 2, bar: 2 };
+      safeCreateVault({
+        balances,
+        qty: new PositiveFiniteInteger(1),
+        address: 'foo',
+        vaults: {},
+        lockLength: new BlockHeight(lockLength),
+        id: 'new-vault-id',
+        startHeight: new BlockHeight(0),
+      });
+    }).toThrowError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
+  });
 
   it('should create vault in address with qty and lock length, and decrement address, by qty in balances object', () => {
     const balances = { foo: 2, bar: 2 };
@@ -95,14 +96,14 @@ describe('safeCreateVault function', () => {
       id: 'new-vault-id',
       address,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
     });
 
     const expectedVault = {
       balance: qty.valueOf(),
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     expect(balances).toEqual({ foo: 1, bar: 2 });
     expect(vaults[address][id]).toEqual(expectedVault);
@@ -124,7 +125,7 @@ describe('safeCreateVault function', () => {
     const expectedNewVault = {
       balance: qty.valueOf(),
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeCreateVault({
       balances,
@@ -132,7 +133,7 @@ describe('safeCreateVault function', () => {
       id: 'new-vault-id',
       address,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
     });
     expect(balances).toEqual({ foo: 2, bar: 1 });
@@ -155,7 +156,7 @@ describe('safeCreateVault function', () => {
     const newVault = {
       balance: qty.valueOf(),
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeCreateVault({
       balances,
@@ -163,7 +164,7 @@ describe('safeCreateVault function', () => {
       address,
       vaults,
       id: 'new-vault-id',
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       startHeight: new BlockHeight(0),
     });
     expect(balances).toEqual({ foo: 1, bar: 2 });
@@ -192,14 +193,14 @@ describe('safeCreateVault function', () => {
     const newVaultData = {
       balance: qty.valueOf(),
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeCreateVault({
       balances,
       qty,
       address,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       id: 'new-vault-id',
       startHeight: new BlockHeight(0),
     });
@@ -215,14 +216,14 @@ describe('safeCreateVault function', () => {
     const newVaultData = {
       balance: qty.valueOf(),
       start: 0,
-      end: MIN_TOKEN_LOCK_LENGTH,
+      end: MIN_TOKEN_LOCK_BLOCK_LENGTH,
     };
     safeCreateVault({
       balances,
       qty,
       address,
       vaults,
-      lockLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      lockLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       id: 'new-vault-id',
       startHeight: new BlockHeight(0),
     });
@@ -238,7 +239,7 @@ describe('safeExtendVault function', () => {
         vaults: {},
         address: 'bar',
         id: 'non-existent-vault',
-        extendLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        extendLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       });
     }).toThrowError('Invalid vault ID.');
   });
@@ -259,7 +260,7 @@ describe('safeExtendVault function', () => {
         vaults,
         address,
         id: 'non-existent-vault-id',
-        extendLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        extendLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       });
     }).toThrowError('Invalid vault ID.');
   });
@@ -270,34 +271,35 @@ describe('safeExtendVault function', () => {
         vaults: {},
         address: 'bar',
         id: 'non-existent-vault',
-        extendLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        extendLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       });
     }).toThrowError('Invalid vault ID.');
   });
 
-  it.each([0, MIN_TOKEN_LOCK_LENGTH - 1, MAX_TOKEN_LOCK_LENGTH + 1])(
-    'should throw an error if lockLength is invalid %s',
-    (extendLength) => {
-      expect(() => {
-        const address = 'bar';
-        const vaults: RegistryVaults = {
-          [address]: {
-            'existing-vault-id': {
-              balance: 1,
-              end: 100,
-              start: 0,
-            },
+  it.each([
+    0,
+    MIN_TOKEN_LOCK_BLOCK_LENGTH - 1,
+    MAX_TOKEN_LOCK_BLOCK_LENGTH + 1,
+  ])('should throw an error if lockLength is invalid %s', (extendLength) => {
+    expect(() => {
+      const address = 'bar';
+      const vaults: RegistryVaults = {
+        [address]: {
+          'existing-vault-id': {
+            balance: 1,
+            end: 100,
+            start: 0,
           },
-        };
-        safeExtendVault({
-          vaults,
-          address,
-          id: 'existing-vault-id',
-          extendLength: new BlockHeight(extendLength),
-        });
-      }).toThrowError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
-    },
-  );
+        },
+      };
+      safeExtendVault({
+        vaults,
+        address,
+        id: 'existing-vault-id',
+        extendLength: new BlockHeight(extendLength),
+      });
+    }).toThrowError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
+  });
 
   it('should throw error if vault has already ended', () => {
     expect(() => {
@@ -315,7 +317,7 @@ describe('safeExtendVault function', () => {
         vaults,
         address,
         id: 'existing-vault-id',
-        extendLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+        extendLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
       });
     }).toThrowError('This vault has ended.');
   });
@@ -333,14 +335,14 @@ describe('safeExtendVault function', () => {
     };
     const expectedNewVaultData = {
       balance: 1,
-      end: 100 + MIN_TOKEN_LOCK_LENGTH,
+      end: 100 + MIN_TOKEN_LOCK_BLOCK_LENGTH,
       start: 0,
     };
     safeExtendVault({
       vaults,
       address,
       id: 'existing-vault-id',
-      extendLength: new BlockHeight(MIN_TOKEN_LOCK_LENGTH),
+      extendLength: new BlockHeight(MIN_TOKEN_LOCK_BLOCK_LENGTH),
     });
     expect(vaults[address]['existing-vault-id']).toEqual(expectedNewVaultData);
   });
@@ -359,14 +361,14 @@ describe('safeExtendVault function', () => {
     };
     const expectedNewVaultData = {
       balance: 1,
-      end: MAX_TOKEN_LOCK_LENGTH,
+      end: MAX_TOKEN_LOCK_BLOCK_LENGTH,
       start: 0,
     };
     safeExtendVault({
       vaults,
       address,
       id: 'existing-vault-id',
-      extendLength: new BlockHeight(MAX_TOKEN_LOCK_LENGTH - currentEnd),
+      extendLength: new BlockHeight(MAX_TOKEN_LOCK_BLOCK_LENGTH - currentEnd),
     });
     expect(vaults[address]['existing-vault-id']).toEqual(expectedNewVaultData);
   });

--- a/src/vaults.ts
+++ b/src/vaults.ts
@@ -1,8 +1,8 @@
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_VAULT_LOCK_LENGTH_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
 } from './constants';
 import {
   Balances,
@@ -44,8 +44,8 @@ export function safeCreateVault({
   }
 
   if (
-    lockLength.valueOf() < MIN_TOKEN_LOCK_LENGTH ||
-    lockLength.valueOf() > MAX_TOKEN_LOCK_LENGTH
+    lockLength.valueOf() < MIN_TOKEN_LOCK_BLOCK_LENGTH ||
+    lockLength.valueOf() > MAX_TOKEN_LOCK_BLOCK_LENGTH
   ) {
     throw new ContractError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
   }
@@ -86,9 +86,9 @@ export function safeExtendVault({
   const totalBlocksRemaining = currentEnd - +SmartWeave.block.height;
 
   if (
-    extendLength.valueOf() < MIN_TOKEN_LOCK_LENGTH ||
-    extendLength.valueOf() > MAX_TOKEN_LOCK_LENGTH ||
-    totalBlocksRemaining + extendLength.valueOf() > MAX_TOKEN_LOCK_LENGTH
+    extendLength.valueOf() < MIN_TOKEN_LOCK_BLOCK_LENGTH ||
+    extendLength.valueOf() > MAX_TOKEN_LOCK_BLOCK_LENGTH ||
+    totalBlocksRemaining + extendLength.valueOf() > MAX_TOKEN_LOCK_BLOCK_LENGTH
   ) {
     throw new ContractError(INVALID_VAULT_LOCK_LENGTH_MESSAGE);
   }

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -9,11 +9,11 @@ import {
 import { calculateAuctionPriceForBlock } from '../src/auctions';
 import {
   ARNS_NAME_RESERVED_MESSAGE,
+  ARNS_NON_EXPIRED_NAME_MESSAGE,
   AUCTION_SETTINGS,
   DEFAULT_UNDERNAME_COUNT,
   INVALID_INPUT_MESSAGE,
   MINIMUM_ALLOWED_NAME_LENGTH,
-  NON_EXPIRED_ARNS_NAME_MESSAGE,
   SHORT_NAME_RESERVATION_UNLOCK_TIMESTAMP,
 } from '../src/constants';
 import { ArNSAuctionData, BlockHeight, IOState } from '../src/types';
@@ -349,7 +349,7 @@ describe('Auctions', () => {
               );
               expect(
                 cachedValue.errorMessages[writeInteraction.originalTxId],
-              ).toEqual(NON_EXPIRED_ARNS_NAME_MESSAGE);
+              ).toEqual(ARNS_NON_EXPIRED_NAME_MESSAGE);
               expect(auctions[auctionBid.name]).toBeUndefined();
               expect(balances).toEqual(prevState.balances);
             });

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -2,11 +2,11 @@ import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import {
+  ARNS_INVALID_EXTENSION_MESSAGE,
+  ARNS_LEASE_LENGTH_MAX_YEARS,
   ARNS_NAME_DOES_NOT_EXIST_MESSAGE,
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_INPUT_MESSAGE,
-  INVALID_NAME_EXTENSION_TYPE_MESSAGE,
-  MAX_YEARS,
   REGISTRATION_TYPES,
   SECONDS_IN_A_YEAR,
 } from './utils/constants';
@@ -98,8 +98,8 @@ describe('Extend', () => {
       },
     );
 
-    it(`should not be able to extend a record for more than ${MAX_YEARS} years`, async () => {
-      const extendYears = MAX_YEARS + 1;
+    it(`should not be able to extend a record for more than ${ARNS_LEASE_LENGTH_MAX_YEARS} years`, async () => {
+      const extendYears = ARNS_LEASE_LENGTH_MAX_YEARS + 1;
       const name = 'name1';
       const { cachedValue: prevCachedValue } = await contract.readState();
       const prevState = prevCachedValue.state as IOState;
@@ -123,7 +123,7 @@ describe('Extend', () => {
 
     it('should not be able to extend a non-existent name ', async () => {
       // advance current timer
-      const extendYears = MAX_YEARS - 1;
+      const extendYears = ARNS_LEASE_LENGTH_MAX_YEARS - 1;
       const name = 'non-existent-name';
 
       const writeInteraction = await contract.writeInteraction({
@@ -161,7 +161,7 @@ describe('Extend', () => {
         writeInteraction.originalTxId,
       );
       expect(cachedValue.errorMessages[writeInteraction.originalTxId]).toEqual(
-        INVALID_NAME_EXTENSION_TYPE_MESSAGE,
+        ARNS_INVALID_EXTENSION_MESSAGE,
       );
       expect(cachedValue.state).toEqual(prevState);
     });
@@ -216,7 +216,7 @@ describe('Extend', () => {
     it.each([1, 2, 3, 4])(
       'should be able to extend name not in grace period and not expired by %s years ',
       async (years) => {
-        const name = `lease-length-name${MAX_YEARS - years}`; // should select the name correctly based on how the helper function generates names
+        const name = `lease-length-name${ARNS_LEASE_LENGTH_MAX_YEARS - years}`; // should select the name correctly based on how the helper function generates names
         const { cachedValue: prevCachedValue } = await contract.readState();
         const prevState = prevCachedValue.state as IOState;
         const prevBalance = prevState.balances[nonContractOwnerAddress];

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -3,13 +3,13 @@ import { Contract, JWKInterface, PstState } from 'warp-contracts';
 import { BlockTimestamp, IOState } from '../src/types';
 import {
   ANT_CONTRACT_IDS,
+  ARNS_INVALID_SHORT_NAME,
+  ARNS_LEASE_LENGTH_MAX_YEARS,
   ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE,
   ARNS_NAME_RESERVED_MESSAGE,
+  ARNS_NON_EXPIRED_NAME_MESSAGE,
   DEFAULT_UNDERNAME_COUNT,
   INVALID_INPUT_MESSAGE,
-  INVALID_SHORT_NAME,
-  MAX_YEARS,
-  NON_EXPIRED_ARNS_NAME_MESSAGE,
 } from './utils/constants';
 import {
   calculatePermabuyFee,
@@ -242,7 +242,7 @@ describe('Records', () => {
         writeInteraction.originalTxId,
       );
       expect(cachedValue.errorMessages[writeInteraction.originalTxId]).toEqual(
-        NON_EXPIRED_ARNS_NAME_MESSAGE,
+        ARNS_NON_EXPIRED_NAME_MESSAGE,
       );
       expect(cachedValue.state).toEqual(prevState);
     });
@@ -356,7 +356,11 @@ describe('Records', () => {
       },
     );
 
-    it.each([MAX_YEARS + 1, MAX_YEARS + 10, MAX_YEARS + 100])(
+    it.each([
+      ARNS_LEASE_LENGTH_MAX_YEARS + 1,
+      ARNS_LEASE_LENGTH_MAX_YEARS + 10,
+      ARNS_LEASE_LENGTH_MAX_YEARS + 100,
+    ])(
       'should not be able to purchase a name with years not within allowed range: %s',
       async (badYear) => {
         const namePurchase = {
@@ -429,7 +433,7 @@ describe('Records', () => {
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       expect(cachedValue.errorMessages[writeInteraction.originalTxId]).toEqual(
-        INVALID_SHORT_NAME,
+        ARNS_INVALID_SHORT_NAME,
       );
       expect(cachedValue.state).toEqual(prevState);
     });

--- a/tests/utils/constants.ts
+++ b/tests/utils/constants.ts
@@ -32,7 +32,7 @@ export const EXAMPLE_OBSERVER_REPORT_TX_IDS = [
   'U35xQUnop2Oq1NwhpzRfTeXVSjC0M8H50MVlmo_cTJc',
   'TtXk8kqgGYVqTQeHaJzst3toA2qz9UO0AGX1lUeuxvc',
 ];
-
+export const DEFAULT_START_HEIGHT = 0;
 export const EXAMPLE_LIST_OF_FAILED_GATEWAYS = [
   EXAMPLE_OBSERVER_REPORT_TX_IDS.concat(['fakeone']),
 ];

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -6,12 +6,12 @@ import path from 'path';
 import { BlockHeight, Gateways, IOState } from '../../src/types';
 import {
   ANT_CONTRACT_IDS,
+  ARNS_LEASE_LENGTH_MAX_YEARS,
   AUCTION_SETTINGS,
   CONTRACT_SETTINGS,
   DEFAULT_UNDERNAME_COUNT,
-  FEE_STRUCTURE,
+  GENESIS_FEES,
   INITIAL_STATE,
-  MAX_YEARS,
   NETWORK_JOIN_STATUS,
   NETWORK_LEAVING_STATUS,
   REGISTRATION_TYPES,
@@ -64,7 +64,7 @@ export async function createLocalWallet(
   };
 }
 
-function createRecords(count = MAX_YEARS) {
+function createRecords(count = ARNS_LEASE_LENGTH_MAX_YEARS) {
   const records: any = {};
   for (let i = 0; i < count; i++) {
     const name = `name${i + 1}`;
@@ -291,7 +291,7 @@ export async function setupInitialContractState(
   const state: IOState = INITIAL_STATE as unknown as IOState;
 
   // set the fees
-  state.fees = FEE_STRUCTURE;
+  state.fees = GENESIS_FEES;
 
   // create wallets and set balances
   state.balances = wallets.reduce((current: any, wallet) => {
@@ -380,4 +380,5 @@ export function getLocalArNSContractKey(key: 'srcTxId' | 'id' = 'id'): string {
 export * from '../../src/utilities';
 export * from '../../src/pricing';
 export * from '../../src/auctions';
+export * from '../../src/records';
 export * from '../../tools/utilities';

--- a/tests/vaults.test.ts
+++ b/tests/vaults.test.ts
@@ -4,8 +4,8 @@ import { IOState } from '../src/types';
 import {
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_INPUT_MESSAGE,
-  MAX_TOKEN_LOCK_LENGTH,
-  MIN_TOKEN_LOCK_LENGTH,
+  MAX_TOKEN_LOCK_BLOCK_LENGTH,
+  MIN_TOKEN_LOCK_BLOCK_LENGTH,
   TRANSFER_QTY,
 } from './utils/constants';
 import {
@@ -36,14 +36,14 @@ describe('Vaults', () => {
       const writeInteraction = await contract.writeInteraction({
         function: 'createVault',
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       const currentBlock = (await getCurrentBlock(arweave)).valueOf();
       const expectedVault = {
         balance: TRANSFER_QTY,
         start: currentBlock,
-        end: currentBlock + MIN_TOKEN_LOCK_LENGTH,
+        end: currentBlock + MIN_TOKEN_LOCK_BLOCK_LENGTH,
       };
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -68,12 +68,12 @@ describe('Vaults', () => {
       const expectedVault = {
         balance: TRANSFER_QTY,
         start: currentBlock + 1,
-        end: currentBlock + MIN_TOKEN_LOCK_LENGTH + 1,
+        end: currentBlock + MIN_TOKEN_LOCK_BLOCK_LENGTH + 1,
       };
       const writeInteraction = await contract.writeInteraction({
         function: 'createVault',
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -94,8 +94,8 @@ describe('Vaults', () => {
       undefined,
       -1,
       'bad lock length',
-      MIN_TOKEN_LOCK_LENGTH - 1,
-      MAX_TOKEN_LOCK_LENGTH + 1,
+      MIN_TOKEN_LOCK_BLOCK_LENGTH - 1,
+      MAX_TOKEN_LOCK_BLOCK_LENGTH + 1,
     ])(
       'should not be able to create vault with an invalid lock length',
       async (badLockLength) => {
@@ -125,7 +125,7 @@ describe('Vaults', () => {
         const writeInteraction = await contract.writeInteraction({
           function: 'createVault',
           qty: badQty,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         });
 
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -145,7 +145,7 @@ describe('Vaults', () => {
       const writeInteraction = await contract.writeInteraction({
         function: 'createVault',
         qty: Math.pow(TRANSFER_QTY, 10),
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -172,7 +172,7 @@ describe('Vaults', () => {
       const writeInteraction = await contract.writeInteraction({
         function: 'createVault',
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
       const { cachedValue: prevCachedValue } = await contract.readState();
       const prevState = prevCachedValue.state as IOState;
@@ -181,7 +181,7 @@ describe('Vaults', () => {
       const writeInteraction2 = await contract.writeInteraction({
         function: 'extendVault',
         id: existingVaultId,
-        extendLength: MIN_TOKEN_LOCK_LENGTH,
+        extendLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
       expect(writeInteraction2?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -192,11 +192,11 @@ describe('Vaults', () => {
 
       expect(newState.vaults[ownerAddress][existingVaultId].end).toEqual(
         prevState.vaults[ownerAddress][existingVaultId].end +
-          MIN_TOKEN_LOCK_LENGTH,
+          MIN_TOKEN_LOCK_BLOCK_LENGTH,
       );
     });
 
-    it.each([undefined, -1, 'bad lock length', MAX_TOKEN_LOCK_LENGTH])(
+    it.each([undefined, -1, 'bad lock length', MAX_TOKEN_LOCK_BLOCK_LENGTH])(
       'should not be able to extend vault with an invalid lock length',
       async (badLockLength) => {
         const { cachedValue: prevCachedValue } = await contract.readState();
@@ -224,7 +224,7 @@ describe('Vaults', () => {
         const writeInteraction = await contract.writeInteraction({
           function: 'extendVault',
           id: badId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         });
 
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -315,7 +315,7 @@ describe('Vaults', () => {
         const writeInteraction = await contract.writeInteraction({
           function: 'increaseVault',
           id: badId,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         });
 
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -344,14 +344,14 @@ describe('Vaults', () => {
         function: 'vaultedTransfer',
         target: targetAddress,
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       const currentBlock = (await getCurrentBlock(arweave)).valueOf();
       const expectedVault = {
         balance: TRANSFER_QTY,
         start: currentBlock,
-        end: currentBlock + MIN_TOKEN_LOCK_LENGTH,
+        end: currentBlock + MIN_TOKEN_LOCK_BLOCK_LENGTH,
       };
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -380,14 +380,14 @@ describe('Vaults', () => {
         function: 'vaultedTransfer',
         target: srcContractId, // The smartweave contract id acts as the protocol balance
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       const currentBlock = (await getCurrentBlock(arweave)).valueOf();
       const expectedVault = {
         balance: TRANSFER_QTY,
         start: currentBlock,
-        end: currentBlock + MIN_TOKEN_LOCK_LENGTH,
+        end: currentBlock + MIN_TOKEN_LOCK_BLOCK_LENGTH,
       };
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -413,7 +413,7 @@ describe('Vaults', () => {
         function: 'vaultedTransfer',
         target: targetAddress,
         qty: Math.pow(TRANSFER_QTY, 10),
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -435,14 +435,14 @@ describe('Vaults', () => {
         function: 'vaultedTransfer',
         target: ownerAddress,
         qty: TRANSFER_QTY,
-        lockLength: MIN_TOKEN_LOCK_LENGTH,
+        lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
       });
 
       const currentBlock = (await getCurrentBlock(arweave)).valueOf();
       const expectedVault = {
         balance: TRANSFER_QTY,
         start: currentBlock,
-        end: currentBlock + MIN_TOKEN_LOCK_LENGTH,
+        end: currentBlock + MIN_TOKEN_LOCK_BLOCK_LENGTH,
       };
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -467,7 +467,7 @@ describe('Vaults', () => {
           function: 'vaultedTransfer',
           target: badWallet,
           qty: TRANSFER_QTY,
-          lockLength: MIN_TOKEN_LOCK_LENGTH,
+          lockLength: MIN_TOKEN_LOCK_BLOCK_LENGTH,
         });
 
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
@@ -486,8 +486,8 @@ describe('Vaults', () => {
       undefined,
       -1,
       'bad lock length',
-      MIN_TOKEN_LOCK_LENGTH - 1,
-      MAX_TOKEN_LOCK_LENGTH + 1,
+      MIN_TOKEN_LOCK_BLOCK_LENGTH - 1,
+      MAX_TOKEN_LOCK_BLOCK_LENGTH + 1,
     ])(
       'should not be able to transfer tokens locked to an invalid wallet address',
       async (badLockLength) => {


### PR DESCRIPTION
The diff is fairly large due to the variable name changes, but the tests should sniff out any copy/pasta errors.

There is still more we can do in the cleanup effort - but this is a start