### PR TITLE
feat: remove settings out from state PE-5422

### DIFF
--- a/src/actions/read/auctions.test.ts
+++ b/src/actions/read/auctions.test.ts
@@ -67,7 +67,6 @@ describe('getAuction', () => {
           (1 + ANNUAL_PERCENTAGE_FEE),
         initiator: '',
         contractTxId: '',
-        settings: AUCTION_SETTINGS,
       },
     ],
   ])(`%s`, (_: string, inputState: IOState, expectedReadResult: any) => {

--- a/src/actions/read/auctions.ts
+++ b/src/actions/read/auctions.ts
@@ -5,6 +5,7 @@ import {
   isNameAvailableForAuction,
   isNameRequiredToBeAuction,
 } from '../../auctions';
+import { AUCTION_SETTINGS } from '../../constants';
 import {
   BlockHeight,
   BlockTimestamp,
@@ -18,12 +19,11 @@ export const getAuction = (
   state: DeepReadonly<IOState>,
   { caller, input: { name, type = 'lease' } }: PstAction,
 ): ContractReadResult => {
-  const { records, auctions, settings, fees, reserved } = state;
+  const { records, auctions, fees, reserved } = state;
   const formattedName = name.toLowerCase().trim();
   const auction = auctions[formattedName];
 
   if (!auction) {
-    const auctionSettings = settings.auctions;
     const currentBlockTimestamp = new BlockTimestamp(
       +SmartWeave.block.timestamp,
     );
@@ -31,7 +31,6 @@ export const getAuction = (
 
     // a stubbed auction object
     const auctionObject = createAuctionObject({
-      auctionSettings,
       type,
       name,
       fees,
@@ -43,7 +42,6 @@ export const getAuction = (
     });
 
     const prices = getAuctionPricesForInterval({
-      auctionSettings,
       startHeight: currentBlockHeight, // set it to the current block height
       startPrice: auctionObject.startPrice,
       floorPrice: auctionObject.floorPrice,
@@ -84,14 +82,8 @@ export const getAuction = (
     };
   }
 
-  const {
-    startHeight,
-    floorPrice,
-    startPrice,
-    settings: existingAuctionSettings,
-  } = auction;
-  const expirationHeight =
-    startHeight + existingAuctionSettings.auctionDuration;
+  const { startHeight, floorPrice, startPrice } = auction;
+  const expirationHeight = startHeight + AUCTION_SETTINGS.auctionDuration;
   const isRequiredToBeAuctioned = isNameRequiredToBeAuction({
     name: formattedName,
     type: auction.type,
@@ -99,7 +91,6 @@ export const getAuction = (
 
   // get all the prices for the auction
   const prices = getAuctionPricesForInterval({
-    auctionSettings: existingAuctionSettings,
     startHeight: new BlockHeight(startHeight),
     startPrice, // TODO: use IO class class
     floorPrice,
@@ -112,8 +103,6 @@ export const getAuction = (
     startPrice,
     floorPrice,
     currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
-    scalingExponent: existingAuctionSettings.scalingExponent,
-    exponentialDecayRate: existingAuctionSettings.exponentialDecayRate,
   });
 
   // TODO: return stringified function used to compute the current price of the auction so clients can calculate prices per block heights themselves

--- a/src/actions/read/gateways.ts
+++ b/src/actions/read/gateways.ts
@@ -18,7 +18,7 @@ export const getGateway = async (
   state: IOState,
   { caller, input: { target = caller } }: PstAction,
 ): Promise<ContractReadResult & any> => {
-  const { gateways = {}, settings, distributions } = state;
+  const { gateways = {}, distributions } = state;
   if (!(target in gateways)) {
     throw new ContractError(`No gateway found with wallet address ${target}.`);
   }
@@ -34,7 +34,6 @@ export const getGateway = async (
 
   const observerWeights = getObserverWeightsForEpoch({
     gateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
   }).find(
     (observer: WeightedObserver) =>
@@ -64,7 +63,7 @@ export const getGateway = async (
 export const getGateways = async (
   state: IOState,
 ): Promise<ContractReadResult> => {
-  const { gateways, distributions, settings } = state;
+  const { gateways, distributions } = state;
 
   const { epochStartHeight } = getEpochBoundariesForHeight({
     currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
@@ -74,7 +73,6 @@ export const getGateways = async (
 
   const allObserverWeights = getObserverWeightsForEpoch({
     gateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
   });
 

--- a/src/actions/read/gateways.ts
+++ b/src/actions/read/gateways.ts
@@ -1,4 +1,4 @@
-import { EPOCH_BLOCK_LENGTH } from '../../constants';
+import { EPOCH_BLOCK_LENGTH, GATEWAY_REGISTRY_SETTINGS } from '../../constants';
 import {
   getEpochBoundariesForHeight,
   getObserverWeightsForEpoch,
@@ -35,6 +35,7 @@ export const getGateway = async (
   const observerWeights = getObserverWeightsForEpoch({
     gateways,
     epochStartHeight,
+    minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
   }).find(
     (observer: WeightedObserver) =>
       observer.gatewayAddress === target || observer.observerAddress === target,
@@ -74,6 +75,7 @@ export const getGateways = async (
   const allObserverWeights = getObserverWeightsForEpoch({
     gateways,
     epochStartHeight,
+    minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
   });
 
   const gatewaysWithWeights = Object.keys(gateways).reduce(

--- a/src/actions/read/observers.ts
+++ b/src/actions/read/observers.ts
@@ -1,4 +1,8 @@
-import { EPOCH_BLOCK_LENGTH, EPOCH_DISTRIBUTION_DELAY } from '../../constants';
+import {
+  EPOCH_BLOCK_LENGTH,
+  EPOCH_DISTRIBUTION_DELAY,
+  GATEWAY_REGISTRY_SETTINGS,
+} from '../../constants';
 import {
   getEpochBoundariesForHeight,
   getPrescribedObserversForEpoch,
@@ -21,6 +25,7 @@ export const getPrescribedObservers = async (
     epochStartHeight,
     epochEndHeight,
     distributions,
+    minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
   });
 
   return { result: prescribedObservers };

--- a/src/actions/read/observers.ts
+++ b/src/actions/read/observers.ts
@@ -8,7 +8,7 @@ import { BlockHeight, ContractReadResult, IOState } from '../../types';
 export const getPrescribedObservers = async (
   state: IOState,
 ): Promise<ContractReadResult> => {
-  const { settings, gateways, distributions } = state;
+  const { gateways, distributions } = state;
 
   const { epochStartHeight, epochEndHeight } = getEpochBoundariesForHeight({
     currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
@@ -18,7 +18,6 @@ export const getPrescribedObservers = async (
 
   const prescribedObservers = await getPrescribedObserversForEpoch({
     gateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
     epochEndHeight,
     distributions,

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -125,7 +125,7 @@ describe('getPriceForInteraction', () => {
           name: 'existing-auction',
         },
       },
-      904.382075,
+      999.620072,
     ],
     [
       'should return the floor price a new auction and submitAuctionBid',

--- a/src/actions/read/price.test.ts
+++ b/src/actions/read/price.test.ts
@@ -131,16 +131,6 @@ describe('getPriceForInteraction', () => {
       'should return the floor price a new auction and submitAuctionBid',
       {
         ...state,
-        settings: {
-          ...state.settings,
-          auctions: {
-            scalingExponent: 10,
-            exponentialDecayRate: 0.01,
-            auctionDuration: 10,
-            floorPriceMultiplier: 1,
-            startPriceMultiplier: 10,
-          },
-        },
       },
       {
         caller: 'test-caller',

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -97,7 +97,6 @@ export function getPriceForInteraction(
           ),
           currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
           fees: state.fees,
-          auctionSettings: state.settings.auctions,
           demandFactoring: state.demandFactoring,
           type: 'lease',
           initiator: caller,
@@ -111,8 +110,6 @@ export function getPriceForInteraction(
         currentBlockHeight: new BlockHeight(+SmartWeave.block.height),
         startPrice: auction.startPrice,
         floorPrice: auction.floorPrice,
-        scalingExponent: auction.settings.scalingExponent,
-        exponentialDecayRate: auction.settings.exponentialDecayRate,
       });
       fee = minimumAuctionBid.valueOf();
       break;

--- a/src/actions/write/decreaseOperatorStake.ts
+++ b/src/actions/write/decreaseOperatorStake.ts
@@ -25,10 +25,10 @@ export const decreaseOperatorStake = async (
 
   if (
     gateways[caller].operatorStake - qty <
-    GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount
+    GATEWAY_REGISTRY_SETTINGS.minOperatorStake
   ) {
     throw new ContractError(
-      `${qty} is not enough operator stake to maintain the minimum of ${GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount}`,
+      `${qty} is not enough operator stake to maintain the minimum of ${GATEWAY_REGISTRY_SETTINGS.minOperatorStake}`,
     );
   }
 

--- a/src/actions/write/decreaseOperatorStake.ts
+++ b/src/actions/write/decreaseOperatorStake.ts
@@ -1,4 +1,7 @@
-import { NETWORK_LEAVING_STATUS } from '../../constants';
+import {
+  GATEWAY_REGISTRY_SETTINGS,
+  NETWORK_LEAVING_STATUS,
+} from '../../constants';
 import { ContractWriteResult, IOState, PstAction } from '../../types';
 
 // Begins the process to unlocks the vault of a gateway operator
@@ -6,8 +9,7 @@ export const decreaseOperatorStake = async (
   state: IOState,
   { caller, input }: PstAction,
 ): Promise<ContractWriteResult> => {
-  const { settings, gateways = {} } = state;
-  const { registry: registrySettings } = settings;
+  const { gateways = {} } = state;
   // TODO: object parse validation
   const { qty } = input as any;
 
@@ -23,10 +25,10 @@ export const decreaseOperatorStake = async (
 
   if (
     gateways[caller].operatorStake - qty <
-    registrySettings.minNetworkJoinStakeAmount
+    GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount
   ) {
     throw new ContractError(
-      `${qty} is not enough operator stake to maintain the minimum of ${registrySettings.minNetworkJoinStakeAmount}`,
+      `${qty} is not enough operator stake to maintain the minimum of ${GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount}`,
     );
   }
 
@@ -38,7 +40,8 @@ export const decreaseOperatorStake = async (
     balance: qty,
     start: +SmartWeave.block.height,
     end:
-      +SmartWeave.block.height + registrySettings.operatorStakeWithdrawLength,
+      +SmartWeave.block.height +
+      GATEWAY_REGISTRY_SETTINGS.operatorStakeWithdrawLength,
   };
 
   // update state

--- a/src/actions/write/evolveState.ts
+++ b/src/actions/write/evolveState.ts
@@ -1,10 +1,4 @@
-import {
-  DEFAULT_GATEWAY_PERFORMANCE_STATS,
-  INITIAL_EPOCH_DISTRIBUTION_DATA,
-  INITIAL_PROTOCOL_BALANCE,
-  NON_CONTRACT_OWNER_MESSAGE,
-} from '../../constants';
-import { safeTransfer } from '../../transfer';
+import { NON_CONTRACT_OWNER_MESSAGE } from '../../constants';
 import { ContractWriteResult, IOState, PstAction } from '../../types';
 
 // Updates this contract to new source code
@@ -18,50 +12,8 @@ export const evolveState = async (
     throw new ContractError(NON_CONTRACT_OWNER_MESSAGE);
   }
 
-  // bump the protocol balance to the initial amount
-  if (
-    state.balances[owner] >= INITIAL_PROTOCOL_BALANCE &&
-    state.balances[SmartWeave.contract.id] < INITIAL_PROTOCOL_BALANCE
-  ) {
-    const protocolBalance = state.balances[SmartWeave.contract.id] || 0;
-    const differenceFromRequiredMinimum =
-      INITIAL_PROTOCOL_BALANCE - protocolBalance;
-    safeTransfer({
-      balances: state.balances,
-      fromAddress: owner,
-      toAddress: SmartWeave.contract.id,
-      qty: differenceFromRequiredMinimum,
-    });
-  }
-
-  // set the gateway stats
-  const updatedGateways = Object.entries(state.gateways).reduce(
-    (acc, [gatewayAddress, gateway]) => {
-      const stats = DEFAULT_GATEWAY_PERFORMANCE_STATS;
-      const updatedGatewayWithStats = {
-        stats,
-        ...gateway, // put this last so any existing stats persist
-      };
-      // set the gateway stats
-      return {
-        ...acc,
-        [gatewayAddress]: updatedGatewayWithStats,
-      };
-    },
-    {},
-  );
-  state.gateways = updatedGateways;
-
-  // set the distributions and observations
-  if (!state.distributions) {
-    // set up the distributions
-    state.distributions = {
-      ...INITIAL_EPOCH_DISTRIBUTION_DATA,
-    };
-
-    // reset the observations
-    state.observations = {};
-  }
+  // set to null to be compatible from IOState - but we do not use it
+  delete (state as any).settings;
 
   return { state };
 };

--- a/src/actions/write/joinNetwork.test.ts
+++ b/src/actions/write/joinNetwork.test.ts
@@ -22,7 +22,7 @@ const validInput = {
   fqdn: 'test.com',
   note: 'test-note',
   properties: stubbedArweaveTxId,
-  qty: 10,
+  qty: 10000,
 };
 
 describe('joinNetwork', () => {
@@ -70,17 +70,18 @@ describe('joinNetwork', () => {
     expect(error.message).toEqual(INSUFFICIENT_FUNDS_MESSAGE);
   });
 
-  it('should throw an error if the stake amount is less then minimum join amount', async () => {
+  it('should throw an error if the stake amount is less than minimum join amount', async () => {
     const initialState = {
       ...getBaselineState(),
       balances: {
-        'a-gateway-with-balance': 100,
+        'a-gateway-with-balance': 100000,
       },
     };
     const error = await joinNetwork(initialState, {
       caller: 'a-gateway-with-balance',
       input: {
         ...validInput,
+        qty: 1,
       },
     }).catch((e) => e);
     expect(error).toBeInstanceOf(Error);
@@ -91,7 +92,7 @@ describe('joinNetwork', () => {
     const initialState = {
       ...getBaselineState(),
       balances: {
-        'existing-gateway': 10,
+        'existing-gateway': 10000,
       },
       gateways: {
         'existing-gateway': {
@@ -113,8 +114,8 @@ describe('joinNetwork', () => {
     const initialState = {
       ...getBaselineState(),
       balances: {
-        'existing-gateway': 10,
-        'a-new-gateway': 10,
+        'existing-gateway': 10000,
+        'a-new-gateway': 10000,
       },
       gateways: {
         'existing-gateway': {
@@ -137,7 +138,7 @@ describe('joinNetwork', () => {
     const initialState = {
       ...getBaselineState(),
       balances: {
-        [stubbedArweaveTxId]: 10,
+        [stubbedArweaveTxId]: 10000,
       },
     };
     const { state } = await joinNetwork(initialState, {
@@ -147,7 +148,7 @@ describe('joinNetwork', () => {
       },
     });
     expect(state.gateways[stubbedArweaveTxId]).toEqual({
-      operatorStake: 10,
+      operatorStake: 10000,
       settings: {
         port: 1234,
         protocol: 'https',

--- a/src/actions/write/joinNetwork.test.ts
+++ b/src/actions/write/joinNetwork.test.ts
@@ -76,13 +76,6 @@ describe('joinNetwork', () => {
       balances: {
         'a-gateway-with-balance': 100,
       },
-      settings: {
-        ...getBaselineState().settings,
-        registry: {
-          ...getBaselineState().settings.registry,
-          minNetworkJoinStakeAmount: 100,
-        },
-      },
     };
     const error = await joinNetwork(initialState, {
       caller: 'a-gateway-with-balance',
@@ -103,13 +96,6 @@ describe('joinNetwork', () => {
       gateways: {
         'existing-gateway': {
           ...stubbedGatewayData,
-        },
-      },
-      settings: {
-        ...getBaselineState().settings,
-        registry: {
-          ...getBaselineState().settings.registry,
-          minNetworkJoinStakeAmount: 10,
         },
       },
     };
@@ -136,13 +122,6 @@ describe('joinNetwork', () => {
           observerWallet: stubbedArweaveTxId,
         },
       },
-      settings: {
-        ...getBaselineState().settings,
-        registry: {
-          ...getBaselineState().settings.registry,
-          minNetworkJoinStakeAmount: 10,
-        },
-      },
     };
     const error = await joinNetwork(initialState, {
       caller: 'a-new-gateway',
@@ -159,13 +138,6 @@ describe('joinNetwork', () => {
       ...getBaselineState(),
       balances: {
         [stubbedArweaveTxId]: 10,
-      },
-      settings: {
-        ...getBaselineState().settings,
-        registry: {
-          ...getBaselineState().settings.registry,
-          minNetworkJoinStakeAmount: 10,
-        },
       },
     };
     const { state } = await joinNetwork(initialState, {

--- a/src/actions/write/joinNetwork.ts
+++ b/src/actions/write/joinNetwork.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_GATEWAY_PERFORMANCE_STATS,
+  GATEWAY_REGISTRY_SETTINGS,
   INSUFFICIENT_FUNDS_MESSAGE,
   INVALID_GATEWAY_EXISTS_MESSAGE,
   INVALID_GATEWAY_STAKE_AMOUNT_MESSAGE,
@@ -63,8 +64,7 @@ export const joinNetwork = async (
   state: IOState,
   { caller, input }: PstAction,
 ): Promise<ContractWriteResult> => {
-  const { balances, gateways = {}, settings } = state;
-  const { registry: registrySettings } = settings;
+  const { balances, gateways = {} } = state;
 
   const { qty, observerWallet, ...gatewaySettings } = new JoinNetwork(
     input,
@@ -75,7 +75,7 @@ export const joinNetwork = async (
     throw new ContractError(INSUFFICIENT_FUNDS_MESSAGE);
   }
 
-  if (qty < registrySettings.minNetworkJoinStakeAmount) {
+  if (qty < GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount) {
     throw new ContractError(INVALID_GATEWAY_STAKE_AMOUNT_MESSAGE);
   }
 

--- a/src/actions/write/joinNetwork.ts
+++ b/src/actions/write/joinNetwork.ts
@@ -75,7 +75,7 @@ export const joinNetwork = async (
     throw new ContractError(INSUFFICIENT_FUNDS_MESSAGE);
   }
 
-  if (qty < GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount) {
+  if (qty < GATEWAY_REGISTRY_SETTINGS.minOperatorStake) {
     throw new ContractError(INVALID_GATEWAY_STAKE_AMOUNT_MESSAGE);
   }
 

--- a/src/actions/write/saveObservations.ts
+++ b/src/actions/write/saveObservations.ts
@@ -1,5 +1,6 @@
 import {
   EPOCH_BLOCK_LENGTH,
+  GATEWAY_REGISTRY_SETTINGS,
   INVALID_OBSERVATION_CALLER_MESSAGE,
   NETWORK_JOIN_STATUS,
 } from '../../constants';
@@ -69,6 +70,7 @@ export const saveObservations = async (
     epochStartHeight,
     epochEndHeight,
     distributions,
+    minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
   });
 
   // find the observer that is submitting the observation

--- a/src/actions/write/saveObservations.ts
+++ b/src/actions/write/saveObservations.ts
@@ -48,7 +48,7 @@ export const saveObservations = async (
   { caller, input }: PstAction,
 ): Promise<ContractWriteResult> => {
   // get all other relevant state data
-  const { observations, gateways, settings, distributions } = state;
+  const { observations, gateways, distributions } = state;
   const { observerReportTxId, failedGateways } = new SaveObservations(input);
 
   // TODO: check if current height is less than epochZeroStartHeight
@@ -66,7 +66,6 @@ export const saveObservations = async (
 
   const prescribedObservers = await getPrescribedObserversForEpoch({
     gateways,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     epochStartHeight,
     epochEndHeight,
     distributions,

--- a/src/actions/write/submitAuctionBid.test.ts
+++ b/src/actions/write/submitAuctionBid.test.ts
@@ -171,7 +171,6 @@ describe('submitAuctionBid', () => {
               expectedData.floorPrice * AUCTION_SETTINGS.startPriceMultiplier,
             floorPrice: expectedData.floorPrice,
             ...(interactionInput.type === 'lease' ? { years: 1 } : {}),
-            settings: AUCTION_SETTINGS,
           },
         },
       });

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -14,7 +14,6 @@ import { tallyNamePurchase } from '../../pricing';
 import { assertAvailableRecord } from '../../records';
 import {
   ArNSAuctionData,
-  AuctionSettings,
   Balances,
   BlockHeight,
   BlockTimestamp,
@@ -140,8 +139,6 @@ function handleBidForExistingAuction({
     startPrice: existingAuction.startPrice,
     floorPrice: existingAuction.floorPrice,
     currentBlockHeight: currentBlockHeight,
-    exponentialDecayRate: existingAuction.settings.exponentialDecayRate,
-    scalingExponent: existingAuction.settings.scalingExponent,
   });
 
   /**
@@ -274,15 +271,12 @@ function handleBidForNewAuction({
 
   // no current auction, create one and vault the balance (floor price) from the user in the auction
   // calculate the registration fee taking into account demand factoring
-  // get the current auction settings, create one if it doesn't exist yet
-  const currentAuctionSettings: AuctionSettings = state.settings.auctions;
 
   // create the initial auction bid
   const initialAuctionBid = createAuctionObject({
     name,
     type,
     fees: state.fees,
-    auctionSettings: currentAuctionSettings,
     currentBlockTimestamp,
     demandFactoring: state.demandFactoring,
     currentBlockHeight,

--- a/src/actions/write/tick.test.ts
+++ b/src/actions/write/tick.test.ts
@@ -777,7 +777,6 @@ describe('tick', () => {
           balances: initialState.balances,
           distributions: initialState.distributions,
           observations: initialState.observations,
-          settings: initialState.settings,
         });
       expect(balances).toEqual(initialState.balances);
       expect(distributions).toEqual({
@@ -825,7 +824,6 @@ describe('tick', () => {
       balances: initialState.balances,
       distributions: initialState.distributions,
       observations: initialState.observations,
-      settings: initialState.settings,
     });
     expect(balances).toEqual(initialState.balances);
     expect(distributions).toEqual(initialState.distributions);
@@ -854,7 +852,6 @@ describe('tick', () => {
           balances: initialState.balances,
           distributions: initialState.distributions,
           observations: initialState.observations,
-          settings: initialState.settings,
         });
       expect(balances).toEqual(initialState.balances);
       expect(distributions).toEqual(initialState.distributions);
@@ -881,7 +878,6 @@ describe('tick', () => {
       balances: initialState.balances,
       distributions: initialState.distributions,
       observations: initialState.observations,
-      settings: initialState.settings,
     });
     const expectedNewEpochStartHeight = EPOCH_BLOCK_LENGTH;
     const expectedNewEpochEndHeight =
@@ -914,7 +910,6 @@ describe('tick', () => {
       balances: initialState.balances,
       distributions: initialState.distributions,
       observations: initialState.observations,
-      settings: initialState.settings,
     });
     expect(balances).toEqual({
       ...initialState.balances,
@@ -980,7 +975,6 @@ describe('tick', () => {
       balances: initialState.balances,
       distributions: initialState.distributions,
       observations: initialState.observations,
-      settings: initialState.settings,
     });
     const totalRewardsEligible = 10_000_000 * 0.0025;
     const totalObserverReward = totalRewardsEligible * 0.05; // 5% of the total distributions

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -6,6 +6,7 @@ import {
   EPOCH_DISTRIBUTION_DELAY,
   EPOCH_REWARD_PERCENTAGE,
   GATEWAY_PERCENTAGE_OF_EPOCH_REWARD,
+  GATEWAY_REGISTRY_SETTINGS,
   INITIAL_EPOCH_DISTRIBUTION_DATA,
   OBSERVATION_FAILURE_THRESHOLD,
   SECONDS_IN_A_YEAR,
@@ -466,6 +467,7 @@ export async function tickRewardDistribution({
     epochStartHeight,
     epochEndHeight,
     distributions,
+    minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
   });
 
   // TODO: consider having this be a set, gateways can not run on the same wallet

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -26,7 +26,6 @@ import {
   Balances,
   BlockHeight,
   BlockTimestamp,
-  ContractSettings,
   ContractWriteResult,
   DeepReadonly,
   DemandFactoringData,
@@ -127,7 +126,6 @@ async function tickInternal({
         updatedState.distributions || INITIAL_EPOCH_DISTRIBUTION_DATA,
       observations: updatedState.observations || {},
       balances: updatedState.balances,
-      settings: updatedState.settings,
     }),
   );
 
@@ -418,14 +416,12 @@ export async function tickRewardDistribution({
   distributions,
   observations,
   balances,
-  settings,
 }: {
   currentBlockHeight: BlockHeight;
   gateways: DeepReadonly<Gateways>;
   distributions: DeepReadonly<EpochDistributionData>;
   observations: DeepReadonly<Observations>;
   balances: DeepReadonly<Balances>;
-  settings: DeepReadonly<ContractSettings>;
 }): Promise<Pick<IOState, 'distributions' | 'balances' | 'gateways'>> {
   const updatedBalances: Balances = {};
   const updatedGateways: Gateways = {};
@@ -469,7 +465,6 @@ export async function tickRewardDistribution({
     gateways,
     epochStartHeight,
     epochEndHeight,
-    minNetworkJoinStakeAmount: settings.registry.minNetworkJoinStakeAmount,
     distributions,
   });
 

--- a/src/auctions.test.ts
+++ b/src/auctions.test.ts
@@ -49,8 +49,6 @@ describe('calculateAuctionPriceForBlock', () => {
         startPrice,
         floorPrice,
         currentBlockHeight,
-        exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
-        scalingExponent: AUCTION_SETTINGS.scalingExponent,
       });
       const percentDifference = Math.abs(
         1 - expectedPrice / priceAtBlock.valueOf(),
@@ -74,17 +72,12 @@ describe('calculateAuctionPriceForBlock', () => {
       [[10, 0, 0.001, 90], 100],
     ])(
       'given [current block height, moving average purchase count] of %j, should return %d',
-      (
-        [startHeight, currentHeight, exponentialDecayRate, scalingExponent],
-        expectedPrice,
-      ) => {
+      ([startHeight, currentHeight], expectedPrice) => {
         const calculatedMinimumBid = calculateAuctionPriceForBlock({
           startHeight: new BlockHeight(startHeight),
           startPrice: 100,
           floorPrice: 10,
           currentBlockHeight: new BlockHeight(currentHeight),
-          exponentialDecayRate,
-          scalingExponent,
         });
         expect(calculatedMinimumBid.valueOf()).toEqual(expectedPrice);
       },
@@ -92,17 +85,8 @@ describe('calculateAuctionPriceForBlock', () => {
   });
 
   describe('getAuctionPricesForInterval function', () => {
-    const baseAuctionSettings = {
-      auctionDuration: 3,
-      exponentialDecayRate: 0.001,
-      scalingExponent: 90,
-      floorPriceMultiplier: 1,
-      startPriceMultiplier: 10,
-    };
-
     it('should return the correct prices for all block heights', () => {
       const prices = getAuctionPricesForInterval({
-        auctionSettings: baseAuctionSettings,
         startHeight: new BlockHeight(0),
         startPrice: 100,
         floorPrice: 10,
@@ -126,13 +110,6 @@ describe('calculateAuctionPriceForBlock', () => {
       floorPrice: 10,
       initiator: 'initiator',
       contractTxId: 'atomic',
-      settings: {
-        auctionDuration: 3,
-        exponentialDecayRate: 0.1,
-        scalingExponent: 90,
-        floorPriceMultiplier: 1,
-        startPriceMultiplier: 10,
-      },
     };
 
     it.each([
@@ -183,13 +160,6 @@ describe('calculateExistingAuctionBidForCaller function', () => {
     initiator: '',
     contractTxId: '',
     years: 1,
-    settings: {
-      auctionDuration: Number.NEGATIVE_INFINITY,
-      exponentialDecayRate: Number.NEGATIVE_INFINITY,
-      scalingExponent: Number.NEGATIVE_INFINITY,
-      floorPriceMultiplier: Number.NEGATIVE_INFINITY,
-      startPriceMultiplier: Number.NEGATIVE_INFINITY,
-    },
   };
 
   it('should throw if submitted bid is less than the required minimum bid', () => {

--- a/src/auctions.test.ts
+++ b/src/auctions.test.ts
@@ -60,13 +60,13 @@ describe('calculateAuctionPriceForBlock', () => {
     it.each([
       // we keep the scalingComponent consistent to make it easier to reason about the test cases, and to represent the decay in the auction curve for block heights and varying decay rates
       [[0, 0, 0.001, 90], 100],
-      [[0, 1, 0.001, 90], 91.389003],
-      [[0, 2, 0.001, 90], 83.511968],
-      [[0, 3, 0.001, 90], 76.306977],
+      [[0, 1, 0.001, 90], 99.962007],
+      [[0, 2, 0.001, 90], 99.924029],
+      [[0, 3, 0.001, 90], 99.886065],
       [[0, 0, 0.002, 90], 100],
-      [[0, 1, 0.002, 90], 83.511968],
-      [[0, 2, 0.002, 90], 69.717284],
-      [[0, 3, 0.002, 90], 58.180118],
+      [[0, 1, 0.002, 90], 99.962007],
+      [[0, 2, 0.002, 90], 99.924029],
+      [[0, 3, 0.002, 90], 99.886065],
       // block heights before the start height should just return the start price
       [[10, 9, 0.001, 90], 100],
       [[10, 0, 0.001, 90], 100],
@@ -92,12 +92,18 @@ describe('calculateAuctionPriceForBlock', () => {
         floorPrice: 10,
         blocksPerInterval: 1,
       });
-      expect(prices).toEqual({
-        0: 100,
-        1: 91.389003,
-        2: 83.511968,
-        3: 76.306977,
-      });
+
+      expect(prices[0]).toEqual(100);
+      expect(prices[1000]).toEqual(68.360124);
+      expect(prices[2000]).toEqual(46.695422);
+      expect(prices[3000]).toEqual(31.872273);
+      expect(prices[4000]).toEqual(21.737906);
+      expect(prices[5000]).toEqual(14.814499);
+      expect(prices[6000]).toEqual(10.088334);
+      expect(prices[7000]).toEqual(10);
+      expect(prices[8000]).toEqual(10);
+      expect(prices[9000]).toEqual(10);
+      expect(prices[10079]).toEqual(10);
     });
   });
 

--- a/src/auctions.test.ts
+++ b/src/auctions.test.ts
@@ -58,18 +58,16 @@ describe('calculateAuctionPriceForBlock', () => {
     });
 
     it.each([
-      // we keep the scalingComponent consistent to make it easier to reason about the test cases, and to represent the decay in the auction curve for block heights and varying decay rates
-      [[0, 0, 0.001, 90], 100],
-      [[0, 1, 0.001, 90], 99.962007],
-      [[0, 2, 0.001, 90], 99.924029],
-      [[0, 3, 0.001, 90], 99.886065],
-      [[0, 0, 0.002, 90], 100],
-      [[0, 1, 0.002, 90], 99.962007],
-      [[0, 2, 0.002, 90], 99.924029],
-      [[0, 3, 0.002, 90], 99.886065],
-      // block heights before the start height should just return the start price
-      [[10, 9, 0.001, 90], 100],
-      [[10, 0, 0.001, 90], 100],
+      [[0, 0], 100],
+      [[0, 1], 99.962007],
+      [[0, 2], 99.924029],
+      [[0, 3], 99.886065],
+      [[0, 1], 99.962007],
+      [[0, 2], 99.924029],
+      [[0, 3], 99.886065],
+      // block heights before the start should just return the start price
+      [[10, 9], 100],
+      [[10, 0], 100],
     ])(
       'given [current block height, moving average purchase count] of %j, should return %d',
       ([startHeight, currentHeight], expectedPrice) => {
@@ -93,6 +91,7 @@ describe('calculateAuctionPriceForBlock', () => {
         blocksPerInterval: 1,
       });
 
+      expect(Object.keys(prices).length).toEqual(10081);
       expect(prices[0]).toEqual(100);
       expect(prices[1000]).toEqual(68.360124);
       expect(prices[2000]).toEqual(46.695422);
@@ -103,7 +102,7 @@ describe('calculateAuctionPriceForBlock', () => {
       expect(prices[7000]).toEqual(10);
       expect(prices[8000]).toEqual(10);
       expect(prices[9000]).toEqual(10);
-      expect(prices[10079]).toEqual(10);
+      expect(prices[10080]).toEqual(10);
     });
   });
 

--- a/src/auctions.ts
+++ b/src/auctions.ts
@@ -1,4 +1,4 @@
-import { SECONDS_IN_A_YEAR } from './constants';
+import { AUCTION_SETTINGS, SECONDS_IN_A_YEAR } from './constants';
 import { calculateRegistrationFee } from './pricing';
 import {
   isActiveReservedName,
@@ -9,7 +9,6 @@ import {
   ArNSAuctionData,
   ArNSBaseAuctionData,
   ArNSNameData,
-  AuctionSettings,
   BlockHeight,
   BlockTimestamp,
   DeepReadonly,
@@ -20,20 +19,19 @@ import {
   ReservedNameData,
 } from './types';
 
+const { auctionDuration, scalingExponent, exponentialDecayRate } =
+  AUCTION_SETTINGS;
+
 export function calculateAuctionPriceForBlock({
   startHeight,
   startPrice,
   floorPrice,
   currentBlockHeight,
-  scalingExponent,
-  exponentialDecayRate,
 }: {
   startHeight: BlockHeight;
   startPrice: number;
   floorPrice: number;
   currentBlockHeight: BlockHeight;
-  scalingExponent: number;
-  exponentialDecayRate: number;
 }): IOToken {
   const blocksSinceStart = currentBlockHeight.valueOf() - startHeight.valueOf();
   const decaySinceStart = exponentialDecayRate * blocksSinceStart;
@@ -46,20 +44,16 @@ export function calculateAuctionPriceForBlock({
 }
 
 export function getAuctionPricesForInterval({
-  auctionSettings,
   startHeight,
   startPrice,
   floorPrice,
   blocksPerInterval,
 }: {
-  auctionSettings: AuctionSettings;
   startHeight: BlockHeight;
   startPrice: number;
   floorPrice: number;
   blocksPerInterval: number;
 }): Record<number, number> {
-  const { auctionDuration, exponentialDecayRate, scalingExponent } =
-    auctionSettings;
   const prices: Record<number, number> = {};
   for (
     let intervalBlockHeight = 0;
@@ -72,8 +66,6 @@ export function getAuctionPricesForInterval({
       startPrice,
       floorPrice,
       currentBlockHeight: new BlockHeight(blockHeightForInterval),
-      exponentialDecayRate,
-      scalingExponent,
     });
     prices[blockHeightForInterval] = price.valueOf();
   }
@@ -81,7 +73,6 @@ export function getAuctionPricesForInterval({
 }
 
 export function createAuctionObject({
-  auctionSettings,
   fees,
   contractTxId,
   currentBlockHeight,
@@ -93,7 +84,6 @@ export function createAuctionObject({
 }: {
   name: string;
   fees: Fees;
-  auctionSettings: AuctionSettings;
   contractTxId: string;
   currentBlockHeight: BlockHeight;
   currentBlockTimestamp: BlockTimestamp;
@@ -110,11 +100,11 @@ export function createAuctionObject({
     demandFactoring,
   });
   const calculatedFloorPrice =
-    initialRegistrationFee * auctionSettings.floorPriceMultiplier;
+    initialRegistrationFee * AUCTION_SETTINGS.floorPriceMultiplier;
   const startPrice =
-    calculatedFloorPrice * auctionSettings.startPriceMultiplier;
+    calculatedFloorPrice * AUCTION_SETTINGS.startPriceMultiplier;
   const endHeight =
-    currentBlockHeight.valueOf() + auctionSettings.auctionDuration;
+    currentBlockHeight.valueOf() + AUCTION_SETTINGS.auctionDuration;
 
   const baseAuctionData: ArNSBaseAuctionData = {
     initiator, // the balance that the floor price is decremented from
@@ -124,7 +114,6 @@ export function createAuctionObject({
     startHeight: currentBlockHeight.valueOf(), // auction starts right away
     endHeight, // auction ends after the set duration
     type,
-    settings: auctionSettings,
   };
   switch (type) {
     case 'permabuy':

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ import {
   DemandFactoringSettings,
   EpochDistributionData,
   GatewayPerformanceStats,
+  GatewayRegistrySettings,
 } from './types';
 
 /**
@@ -227,11 +228,12 @@ export const INITIAL_EPOCH_DISTRIBUTION_DATA: EpochDistributionData = {
     EPOCH_DISTRIBUTION_DELAY,
 };
 
-export const GATEWAY_REGISTRY_SETTINGS = {
-  gatewayLeaveLength: 3600,
+export const GATEWAY_REGISTRY_SETTINGS: GatewayRegistrySettings = {
+  gatewayLeaveLength: 3600, // approximately 5 days
   maxLockLength: 788400,
-  minGatewayJoinLength: 3600,
-  minLockLength: 720,
-  minNetworkJoinStakeAmount: 10000,
-  operatorStakeWithdrawLength: 3600,
+  minGatewayJoinLength: 3600, // TODO: remove this as gatewayLeaveLength achieves the same thing
+  minLockLength: 720, // 1 day
+  minOperatorStake: 10000,
+  operatorStakeWithdrawLength: 3600, // TODO: bump to 90 days
+  // TODO: add delegatedStakeWithdrawLength to 30 days
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -226,3 +226,12 @@ export const INITIAL_EPOCH_DISTRIBUTION_DATA: EpochDistributionData = {
     1 +
     EPOCH_DISTRIBUTION_DELAY,
 };
+
+export const GATEWAY_REGISTRY_SETTINGS = {
+  gatewayLeaveLength: 3600,
+  maxLockLength: 788400,
+  minGatewayJoinLength: 3600,
+  minLockLength: 720,
+  minNetworkJoinStakeAmount: 10000,
+  operatorStakeWithdrawLength: 3600,
+};

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -55,7 +55,6 @@ describe('getPrescribedObserversForEpoch', () => {
         },
       },
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
-      minNetworkJoinStakeAmount: 10,
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + 10),
     });
@@ -99,7 +98,6 @@ describe('getPrescribedObserversForEpoch', () => {
     const observers = await getPrescribedObserversForEpoch({
       gateways: eligibleGateways,
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
-      minNetworkJoinStakeAmount: 10,
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + 10),
     });
@@ -167,7 +165,7 @@ describe('getPrescribedObserversForEpoch', () => {
     const observers = await getPrescribedObserversForEpoch({
       gateways: extendedStubbedGateways,
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
-      minNetworkJoinStakeAmount: 10,
+
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + EPOCH_BLOCK_LENGTH),
     });

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -57,11 +57,12 @@ describe('getPrescribedObserversForEpoch', () => {
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + 10),
+      minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
     });
 
     expect(observers).toBeDefined();
     const expectedStakeWeight =
-      totalStake / GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount;
+      totalStake / GATEWAY_REGISTRY_SETTINGS.minOperatorStake;
     const expectedTenureWeight = epochStartHeight / TENURE_WEIGHT_PERIOD;
     const expectedCompositeWeight = expectedTenureWeight * expectedStakeWeight;
     expect(observers).toEqual([
@@ -100,6 +101,7 @@ describe('getPrescribedObserversForEpoch', () => {
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + 10),
+      minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
     });
     expect(observers).toBeDefined();
     expect(observers.length).toBe(MAXIMUM_OBSERVERS_PER_EPOCH);
@@ -109,7 +111,7 @@ describe('getPrescribedObserversForEpoch', () => {
       const expectedObserverRewardRatioWeight = 1;
       const expectedStakeWeight =
         eligibleGateways[gateway].operatorStake /
-        GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount;
+        GATEWAY_REGISTRY_SETTINGS.minOperatorStake;
       const expectedTenureWeight =
         (epochStartHeight - eligibleGateways[gateway].start) /
         TENURE_WEIGHT_PERIOD;
@@ -166,7 +168,7 @@ describe('getPrescribedObserversForEpoch', () => {
     const observers = await getPrescribedObserversForEpoch({
       gateways: extendedStubbedGateways,
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
-
+      minOperatorStake: GATEWAY_REGISTRY_SETTINGS.minOperatorStake,
       epochStartHeight: new BlockHeight(epochStartHeight),
       epochEndHeight: new BlockHeight(epochStartHeight + EPOCH_BLOCK_LENGTH),
     });

--- a/src/observers.test.ts
+++ b/src/observers.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import {
   EPOCH_BLOCK_LENGTH,
   GATEWAY_LEAVE_BLOCK_LENGTH,
+  GATEWAY_REGISTRY_SETTINGS,
   INITIAL_EPOCH_DISTRIBUTION_DATA,
   MAXIMUM_OBSERVERS_PER_EPOCH,
   TENURE_WEIGHT_PERIOD,
@@ -44,7 +45,6 @@ describe('getPrescribedObserversForEpoch', () => {
   it(`should return the all eligible observers with proper weights if the total number is less than ${MAXIMUM_OBSERVERS_PER_EPOCH}`, async () => {
     const epochStartHeight = 10;
     const totalStake = 100;
-    const minNetworkJoinStakeAmount = 10;
     const observers = await getPrescribedObserversForEpoch({
       gateways: {
         'test-observer-wallet-1': {
@@ -60,7 +60,8 @@ describe('getPrescribedObserversForEpoch', () => {
     });
 
     expect(observers).toBeDefined();
-    const expectedStakeWeight = totalStake / minNetworkJoinStakeAmount;
+    const expectedStakeWeight =
+      totalStake / GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount;
     const expectedTenureWeight = epochStartHeight / TENURE_WEIGHT_PERIOD;
     const expectedCompositeWeight = expectedTenureWeight * expectedStakeWeight;
     expect(observers).toEqual([
@@ -94,7 +95,6 @@ describe('getPrescribedObserversForEpoch', () => {
       };
     }
     const eligibleGateways: DeepReadonly<Gateways> = extendedStubbedGateways;
-    const minNetworkJoinStakeAmount = 10;
     const observers = await getPrescribedObserversForEpoch({
       gateways: eligibleGateways,
       distributions: INITIAL_EPOCH_DISTRIBUTION_DATA,
@@ -108,7 +108,8 @@ describe('getPrescribedObserversForEpoch', () => {
       const expectedGatewayRewardRatioWeight = 1;
       const expectedObserverRewardRatioWeight = 1;
       const expectedStakeWeight =
-        eligibleGateways[gateway].operatorStake / minNetworkJoinStakeAmount;
+        eligibleGateways[gateway].operatorStake /
+        GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount;
       const expectedTenureWeight =
         (epochStartHeight - eligibleGateways[gateway].start) /
         TENURE_WEIGHT_PERIOD;

--- a/src/observers.ts
+++ b/src/observers.ts
@@ -1,5 +1,6 @@
 import {
   EPOCH_BLOCK_LENGTH,
+  GATEWAY_REGISTRY_SETTINGS,
   MAXIMUM_OBSERVERS_PER_EPOCH,
   MAX_TENURE_WEIGHT,
   OBSERVERS_SAMPLED_BLOCKS_COUNT,
@@ -134,18 +135,17 @@ export function getEligibleGatewaysForEpoch({
 export function getObserverWeightsForEpoch({
   gateways,
   epochStartHeight,
-  minNetworkJoinStakeAmount,
 }: {
   gateways: DeepReadonly<Gateways>;
   epochStartHeight: BlockHeight;
-  minNetworkJoinStakeAmount: number; // TODO: replace with constant
 }): WeightedObserver[] {
   const weightedObservers: WeightedObserver[] = [];
   let totalCompositeWeight = 0;
   // Get all eligible observers and assign weights
   for (const [address, gateway] of Object.entries(gateways)) {
     const stake = gateway.operatorStake; // e.g. 100 - no cap to this
-    const stakeWeight = stake / minNetworkJoinStakeAmount; // this is always greater than 1 as the minNetworkJoinStakeAmount is always less than the stake
+    const stakeWeight =
+      stake / GATEWAY_REGISTRY_SETTINGS.minNetworkJoinStakeAmount; // this is always greater than 1 as the minNetworkJoinStakeAmount is always less than the stake
     // the percentage of the epoch the gateway was joined for before this epoch, if the gateway starts in the future this will be 0
     const totalBlocksForGateway = epochStartHeight.valueOf() - gateway.start;
     // TODO: should we increment by one here or are observers that join at the epoch start not eligible to be selected as an observer
@@ -210,13 +210,11 @@ export function getObserverWeightsForEpoch({
 
 export async function getPrescribedObserversForEpoch({
   gateways,
-  minNetworkJoinStakeAmount,
   epochStartHeight,
   epochEndHeight,
 }: {
   gateways: DeepReadonly<Gateways>;
   distributions: DeepReadonly<EpochDistributionData>;
-  minNetworkJoinStakeAmount: number;
   epochStartHeight: BlockHeight;
   epochEndHeight: BlockHeight;
 }): Promise<WeightedObserver[]> {
@@ -229,7 +227,6 @@ export async function getPrescribedObserversForEpoch({
   const weightedObservers = getObserverWeightsForEpoch({
     gateways: eligibleGateways,
     epochStartHeight,
-    minNetworkJoinStakeAmount,
     // filter out any that could have a normalized composite weight of 0 to avoid infinite loops when randomly selecting prescribed observers below
   }).filter((observer) => observer.normalizedCompositeWeight > 0); // TODO: this could be some required minimum weight
 

--- a/src/tests/stubs.ts
+++ b/src/tests/stubs.ts
@@ -1,5 +1,4 @@
 import {
-  AUCTION_SETTINGS,
   DEFAULT_GATEWAY_PERFORMANCE_STATS,
   EPOCH_BLOCK_LENGTH,
   EPOCH_DISTRIBUTION_DELAY,
@@ -28,17 +27,7 @@ export const getBaselineState: () => IOState = (): IOState => ({
   reserved: {},
   fees: GENESIS_FEES,
   auctions: {},
-  settings: {
-    registry: {
-      minLockLength: 720,
-      maxLockLength: 788400,
-      minNetworkJoinStakeAmount: 10000,
-      minGatewayJoinLength: 1,
-      gatewayLeaveLength: 1,
-      operatorStakeWithdrawLength: 3600,
-    },
-    auctions: AUCTION_SETTINGS,
-  },
+
   gateways: {},
   lastTickedHeight: 0,
   observations: {},
@@ -57,7 +46,6 @@ export const stubbedAuctionData: ArNSLeaseAuctionData = {
   initiator: 'initiator',
   contractTxId: 'contractTxId',
   years: 1,
-  settings: AUCTION_SETTINGS,
 };
 
 export const stubbedAuctionState: Partial<IOState> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export type IOState = {
   observations: Observations;
   distributions: EpochDistributionData;
   vaults: RegistryVaults;
+  settings?: unknown; // satisfying integration tests type issues
 };
 
 export type GatewayPerformanceStats = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export type IOState = {
   observations: Observations;
   distributions: EpochDistributionData;
   vaults: RegistryVaults;
-  settings?: unknown; // satisfying integration tests type issues
+  settings?: unknown; // satisfies base PstContract type
 };
 
 export type GatewayPerformanceStats = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,6 @@ export type IOState = {
   records: Records; // The list of all ArNS names and their associated data
   gateways: Gateways; // each gateway uses its public arweave wallet address to identify it in the gateway registry
   fees: Fees; // starting list of all fees for purchasing ArNS names
-  settings: ContractSettings; // protocol settings and parameters
   reserved: ReservedNames; // list of all reserved names that are not allowed to be purchased at this time
   auctions: Auctions;
   lastTickedHeight: number; // periodicity management
@@ -96,7 +95,6 @@ export type ArNSBaseAuctionData = {
   type: RegistrationType;
   initiator: string;
   contractTxId: string;
-  settings: AuctionSettings;
 };
 
 export type ArNSLeaseAuctionData = ArNSBaseAuctionData & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,6 @@ export type IOState = {
   observations: Observations;
   distributions: EpochDistributionData;
   vaults: RegistryVaults;
-  settings?: unknown; // satisfies base PstContract type
 };
 
 export type GatewayPerformanceStats = {
@@ -109,7 +108,6 @@ export type ArNSPermabuyAuctionData = ArNSBaseAuctionData & {
 
 export type ArNSAuctionData = ArNSLeaseAuctionData | ArNSPermabuyAuctionData;
 
-// TODO: Since we're not allowing mutability of this via governance, we could do away with ID-based settings
 export type AuctionSettings = {
   floorPriceMultiplier: number;
   startPriceMultiplier: number;
@@ -121,18 +119,15 @@ export type AuctionSettings = {
 export type GatewayRegistrySettings = {
   minLockLength: number; // the minimum amount of blocks tokens can be locked in a community vault
   maxLockLength: number; // the maximum amount of blocks tokens can be locked in a community vault
-  minNetworkJoinStakeAmount: number; // the minimum amount of tokens needed to stake to join the ar.io network as a gateway
+  minOperatorStake: number; // the minimum amount of tokens needed to stake to join the ar.io network as a gateway
+  // TODO: remove this number - it's achieved by gatewayLeaveLength
   minGatewayJoinLength: number; // the minimum amount of blocks a gateway can be joined to the ar.io network
   gatewayLeaveLength: number; // the amount of blocks that have to elapse before a gateway leaves the network
   operatorStakeWithdrawLength: number; // the amount of blocks that have to elapse before a gateway operator's stake is returned
+  // TODO: add delegatedStakeWithdrawLength for delegated staking
 };
 
 // TODO: these will be moved to constants
-export type ContractSettings = {
-  // these settings control the various capabilities in the contract
-  registry: GatewayRegistrySettings;
-  auctions: AuctionSettings;
-};
 
 const gatewayStatus = [NETWORK_JOIN_STATUS, NETWORK_LEAVING_STATUS] as const;
 export type GatewayStatus = (typeof gatewayStatus)[number];

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -304,13 +304,6 @@ describe('resetProtocolBalance function', () => {
           initiator: 'address-3',
           contractTxId: '',
           years: 1,
-          settings: {
-            auctionDuration: 0,
-            exponentialDecayRate: 0,
-            scalingExponent: 0,
-            floorPriceMultiplier: 0,
-            startPriceMultiplier: 0,
-          },
         },
       },
       gateways: {

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -1,7 +1,6 @@
 import {
   Contract,
   JWKInterface,
-  PstState,
   WriteInteractionOptions,
   WriteInteractionResponse,
 } from 'warp-contracts';
@@ -27,7 +26,7 @@ import {
 import { arweave, warp } from './utils/services';
 
 describe('Auctions', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
 
   beforeAll(async () => {
@@ -40,7 +39,9 @@ describe('Auctions', () => {
 
     beforeAll(async () => {
       nonContractOwner = getLocalWallet(1);
-      contract = warp.pst(srcContractId).connect(nonContractOwner);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(nonContractOwner);
       nonContractOwnerAddress = await arweave.wallets.getAddress(
         nonContractOwner,
       );
@@ -669,7 +670,7 @@ describe('Auctions', () => {
 });
 
 async function writeInteractionOrFail<Input = unknown>(
-  contract: Contract<PstState>,
+  contract: Contract<IOState>,
   input: Input,
   options?: WriteInteractionOptions,
 ): Promise<WriteInteractionResponse> {

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -213,7 +213,6 @@ describe('Auctions', () => {
                   initiator: nonContractOwnerAddress,
                   contractTxId: ANT_CONTRACT_IDS[0],
                   years: 1,
-                  settings: AUCTION_SETTINGS,
                 }),
               );
               expect(balances[nonContractOwnerAddress]).toEqual(
@@ -273,8 +272,6 @@ describe('Auctions', () => {
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
                   currentBlockHeight: await getCurrentBlock(arweave),
-                  scalingExponent: AUCTION_SETTINGS.scalingExponent,
-                  exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
                 }).valueOf();
                 const auctionBid = {
                   name: 'apple',
@@ -296,8 +293,6 @@ describe('Auctions', () => {
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
                   currentBlockHeight: await getCurrentBlock(arweave),
-                  scalingExponent: AUCTION_SETTINGS.scalingExponent,
-                  exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
                 }).valueOf();
                 expect(writeInteraction?.originalTxId).not.toBeUndefined();
                 const { cachedValue } = await contract.readState();
@@ -452,7 +447,6 @@ describe('Auctions', () => {
                 initiator: nonContractOwnerAddress,
                 contractTxId: ANT_CONTRACT_IDS[0],
                 years: 1,
-                settings: AUCTION_SETTINGS,
               });
               expect(balances[nonContractOwnerAddress]).toEqual(
                 prevState.balances[nonContractOwnerAddress] -
@@ -498,7 +492,6 @@ describe('Auctions', () => {
               AUCTION_SETTINGS.auctionDuration,
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
-            settings: AUCTION_SETTINGS,
           });
           expect(balances[nonContractOwnerAddress]).toEqual(
             prevState.balances[nonContractOwnerAddress] -
@@ -524,8 +517,6 @@ describe('Auctions', () => {
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            scalingExponent: AUCTION_SETTINGS.scalingExponent,
-            exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
           }).valueOf();
           const auctionBid = {
             name: 'microsoft',
@@ -547,8 +538,6 @@ describe('Auctions', () => {
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            scalingExponent: AUCTION_SETTINGS.scalingExponent,
-            exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
           }).valueOf();
           expect(writeInteraction?.originalTxId).not.toBeUndefined();
           const { cachedValue } = await contract.readState();
@@ -616,7 +605,6 @@ describe('Auctions', () => {
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
             years: 1,
-            settings: AUCTION_SETTINGS,
           });
           expect(balances[nonContractOwnerAddress]).toEqual(
             prevState.balances[nonContractOwnerAddress] -
@@ -635,8 +623,6 @@ describe('Auctions', () => {
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            scalingExponent: AUCTION_SETTINGS.scalingExponent,
-            exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
           }).valueOf();
           const auctionBid = {
             name: 'tesla',
@@ -653,8 +639,6 @@ describe('Auctions', () => {
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            scalingExponent: AUCTION_SETTINGS.scalingExponent,
-            exponentialDecayRate: AUCTION_SETTINGS.exponentialDecayRate,
           }).valueOf();
           expect(writeInteraction?.originalTxId).not.toBeUndefined();
           const { cachedValue } = await contract.readState();

--- a/tests/balance.test.ts
+++ b/tests/balance.test.ts
@@ -1,11 +1,11 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
 import { arweave, warp } from './utils/services';
 
 describe('Balance', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
 
   beforeAll(async () => {
@@ -17,7 +17,9 @@ describe('Balance', () => {
 
     beforeAll(async () => {
       nonContractOwner = getLocalWallet(1);
-      contract = warp.pst(srcContractId).connect(nonContractOwner);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(nonContractOwner);
     });
 
     it('should able to retrieve its own balance', async () => {

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -1,5 +1,6 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
+import { IOState } from '../src/types';
 import {
   arweave,
   getContractManifest,
@@ -14,7 +15,7 @@ const testnetContractTxId =
 
 describe('evolving', () => {
   let localContractOwnerJWK: JWKInterface;
-  let newForkedContract: Contract<PstState>;
+  let newForkedContract: Contract<IOState>;
   let localSourceCodeId: string;
 
   beforeAll(async () => {
@@ -28,7 +29,7 @@ describe('evolving', () => {
     });
     // fetches the currently deployed contract (on arweave.net) state against the most recent sort key
     const testnetContract = await warpMainnet
-      .contract(testnetContractTxId)
+      .contract<IOState>(testnetContractTxId)
       .setEvaluationOptions(evaluationOptions)
       .syncState(`https://api.arns.app/v1/contract/${testnetContractTxId}`);
     const { cachedValue } = await testnetContract.readState();
@@ -52,7 +53,7 @@ describe('evolving', () => {
         true,
       );
     newForkedContract = warpLocal
-      .pst(newContractTxId)
+      .contract<IOState>(newContractTxId)
       .connect(localContractOwnerJWK);
   });
 

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import {
@@ -20,7 +20,7 @@ import {
 import { arweave, warp } from './utils/services';
 
 describe('Extend', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
 
   beforeAll(async () => {
@@ -37,7 +37,9 @@ describe('Extend', () => {
       nonContractOwnerAddress = await arweave.wallets.getAddress(
         nonContractOwner,
       );
-      contract = warp.pst(srcContractId).connect(nonContractOwner);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(nonContractOwner);
       emptyWalletCaller = await arweave.wallets.generate();
       const emptyWalletAddress = await arweave.wallets.getAddress(
         emptyWalletCaller,

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import {
   Gateway,
@@ -25,7 +25,7 @@ import { arweave, warp } from './utils/services';
 
 describe('Network', () => {
   let nonGatewayOperator: JWKInterface;
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let owner: JWKInterface;
   let ownerAddress: string;
   let srcContractId: string;
@@ -44,7 +44,9 @@ describe('Network', () => {
       newGatewayOperatorAddress = await arweave.wallets.getAddress(
         newGatewayOperator,
       );
-      contract = warp.pst(srcContractId).connect(newGatewayOperator);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(newGatewayOperator);
     });
 
     describe('join network', () => {
@@ -659,7 +661,9 @@ describe('Network', () => {
       owner = getLocalWallet(0);
       ownerAddress = await arweave.wallets.getAddress(owner);
       nonGatewayOperator = getLocalWallet(16);
-      contract = warp.pst(srcContractId).connect(nonGatewayOperator);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(nonGatewayOperator);
     });
 
     describe('read interactions', () => {

--- a/tests/observation.test.ts
+++ b/tests/observation.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { getEpochBoundariesForHeight } from '../src/observers';
 import { BlockHeight, IOState, WeightedObserver } from '../src/types';
@@ -20,7 +20,7 @@ import { arweave, warp } from './utils/services';
 
 describe('Observation', () => {
   const gatewayWalletAddresses: string[] = [];
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
   const wallets: {
     addr: string;
@@ -48,7 +48,7 @@ describe('Observation', () => {
       gatewayWalletAddresses.push(gatewayWalletAddress);
     }
     srcContractId = getLocalArNSContractKey('id');
-    contract = warp.pst(srcContractId);
+    contract = warp.contract<IOState>(srcContractId);
     failedGateways = [
       wallets[0].addr,
       wallets[1].addr,
@@ -93,7 +93,9 @@ describe('Observation', () => {
       it('should save observations in epoch if prescribed observer', async () => {
         const writeInteractions = await Promise.all(
           prescribedObserverWallets.map((wallet) => {
-            contract = warp.pst(srcContractId).connect(wallet.jwk);
+            contract = warp
+              .contract<IOState>(srcContractId)
+              .connect(wallet.jwk);
             return contract.writeInteraction({
               function: 'saveObservations',
               observerReportTxId: EXAMPLE_OBSERVER_REPORT_TX_IDS[0],
@@ -139,7 +141,7 @@ describe('Observation', () => {
           previousState.observations[currentEpochStartHeight.valueOf()]
             ?.reports;
         contract = warp
-          .pst(srcContractId)
+          .contract<IOState>(srcContractId)
           .connect(prescribedObserverWallets[0].jwk);
         const writeInteraction = await contract.writeInteraction({
           function: 'saveObservations',
@@ -195,7 +197,9 @@ describe('Observation', () => {
       it('should save observations if prescribed observer with all using multiple failed gateways', async () => {
         const writeInteractions = await Promise.all(
           prescribedObserverWallets.map((wallet) => {
-            contract = warp.pst(srcContractId).connect(wallet.jwk);
+            contract = warp
+              .contract<IOState>(srcContractId)
+              .connect(wallet.jwk);
             return contract.writeInteraction({
               function: 'saveObservations',
               observerReportTxId: EXAMPLE_OBSERVER_REPORT_TX_IDS[0],
@@ -244,7 +248,9 @@ describe('Observation', () => {
           prevState.observations[currentEpochStartHeight.valueOf()];
         const writeInteractions = await Promise.all(
           prescribedObserverWallets.map((wallet) => {
-            contract = warp.pst(srcContractId).connect(wallet.jwk);
+            contract = warp
+              .contract<IOState>(srcContractId)
+              .connect(wallet.jwk);
             return contract.writeInteraction({
               function: 'saveObservations',
               observerReportTxId: EXAMPLE_OBSERVER_REPORT_TX_IDS[1],
@@ -286,7 +292,9 @@ describe('Observation', () => {
       it('should not save observation report if not prescribed observer', async () => {
         const { cachedValue: prevCachedValue } = await contract.readState();
         const nonPrescribedObserver = wallets[8].jwk; // not allowed to observe
-        contract = warp.pst(srcContractId).connect(nonPrescribedObserver);
+        contract = warp
+          .contract<IOState>(srcContractId)
+          .connect(nonPrescribedObserver);
         const writeInteraction = await contract.writeInteraction({
           function: 'saveObservations',
           observerReportTxId: EXAMPLE_OBSERVER_REPORT_TX_IDS[0],
@@ -303,7 +311,9 @@ describe('Observation', () => {
       it('should not save observation report if the caller is not a registered observer', async () => {
         const notJoinedGateway = await createLocalWallet(arweave);
         const { cachedValue: prevCachedValue } = await contract.readState();
-        contract = warp.pst(srcContractId).connect(notJoinedGateway.wallet);
+        contract = warp
+          .contract<IOState>(srcContractId)
+          .connect(notJoinedGateway.wallet);
         const writeInteraction = await contract.writeInteraction({
           function: 'saveObservations',
           observerReportTxId: EXAMPLE_OBSERVER_REPORT_TX_IDS[0],

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { BlockTimestamp, IOState } from '../src/types';
 import {
@@ -20,12 +20,12 @@ import {
 import { arweave, warp } from './utils/services';
 
 describe('Records', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
 
   beforeAll(() => {
     srcContractId = getLocalArNSContractKey('id');
-    contract = warp.pst(srcContractId);
+    contract = warp.contract<IOState>(srcContractId);
   });
 
   describe('any wallet', () => {

--- a/tests/setup.jest.ts
+++ b/tests/setup.jest.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 import * as fs from 'fs';
 import path from 'path';
 
+import { IOState } from '../src/types';
 import { WALLETS_TO_CREATE } from './utils/constants';
 import { createLocalWallet, setupInitialContractState } from './utils/helper';
 import { arlocal, arweave, warp } from './utils/services';
@@ -62,11 +63,14 @@ module.exports = async () => {
   });
 
   // transfer funds to the protocol balance
-  await warp.pst(contractTxId).connect(wallets[0].wallet).writeInteraction({
-    function: 'transfer',
-    target: contractTxId,
-    qty: 1, // just a hack for now - we'll need to give it a balance
-  });
+  await warp
+    .contract<IOState>(contractTxId)
+    .connect(wallets[0].wallet)
+    .writeInteraction({
+      function: 'transfer',
+      target: contractTxId,
+      qty: 1, // just a hack for now - we'll need to give it a balance
+    });
 
   // write contract to local
   fs.writeFileSync(

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import {
@@ -11,7 +11,7 @@ import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
 import { arweave, warp } from './utils/services';
 
 describe('Transfers', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
 
   beforeAll(async () => {
@@ -23,7 +23,7 @@ describe('Transfers', () => {
 
     beforeAll(async () => {
       owner = getLocalWallet(0);
-      contract = warp.pst(srcContractId).connect(owner);
+      contract = warp.contract<IOState>(srcContractId).connect(owner);
     });
 
     it('should be able to transfer tokens to an existing wallet', async () => {
@@ -149,7 +149,9 @@ describe('Transfers', () => {
 
     beforeAll(async () => {
       nonContractOwner = getLocalWallet(1);
-      contract = warp.pst(srcContractId).connect(nonContractOwner);
+      contract = warp
+        .contract<IOState>(srcContractId)
+        .connect(nonContractOwner);
     });
 
     it('should be able to transfer tokens to an existing wallet', async () => {

--- a/tests/utils/constants.ts
+++ b/tests/utils/constants.ts
@@ -1,4 +1,3 @@
-import { GatewayRegistrySettings } from '../../src/types';
 import initialContractState from './initial-state.json';
 
 export enum REGISTRATION_TYPES {
@@ -20,13 +19,13 @@ export const SECONDS_IN_A_YEAR = 31_536_000;
 export const WALLET_FUND_AMOUNT = 1_000_000_000_000_000;
 export const INITIAL_STATE = initialContractState;
 export const TRANSFER_QTY = 100_000;
-export const CONTRACT_SETTINGS: GatewayRegistrySettings = {
-  minLockLength: 5,
-  maxLockLength: 720 * 365 * 3,
-  minNetworkJoinStakeAmount: 10_000,
-  minGatewayJoinLength: 2,
-  gatewayLeaveLength: 2,
-  operatorStakeWithdrawLength: 5,
+export const CONTRACT_SETTINGS = {
+  gatewayLeaveLength: 3600,
+  maxLockLength: 788400,
+  minGatewayJoinLength: 3600,
+  minLockLength: 720,
+  minNetworkJoinStakeAmount: 10000,
+  operatorStakeWithdrawLength: 3600,
 };
 export const EXAMPLE_OBSERVER_REPORT_TX_IDS = [
   'U35xQUnop2Oq1NwhpzRfTeXVSjC0M8H50MVlmo_cTJc',

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -7,8 +7,6 @@ import { BlockHeight, Gateways, IOState } from '../../src/types';
 import {
   ANT_CONTRACT_IDS,
   ARNS_LEASE_LENGTH_MAX_YEARS,
-  AUCTION_SETTINGS,
-  CONTRACT_SETTINGS,
   DEFAULT_GATEWAY_PERFORMANCE_STATS,
   DEFAULT_UNDERNAME_COUNT,
   GENESIS_FEES,
@@ -349,12 +347,6 @@ export async function setupInitialContractState(
 
   // set the owner to the first wallet
   state.owner = owner;
-
-  // configure the necessary contract settings
-  state.settings = {
-    registry: CONTRACT_SETTINGS,
-    auctions: AUCTION_SETTINGS,
-  };
 
   // configure some basic gateways
   state.gateways = createGateways(wallets);

--- a/tests/vaults.test.ts
+++ b/tests/vaults.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstState } from 'warp-contracts';
+import { Contract, JWKInterface } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import {
@@ -16,7 +16,7 @@ import {
 import { arweave, warp } from './utils/services';
 
 describe('Vaults', () => {
-  let contract: Contract<PstState>;
+  let contract: Contract<IOState>;
   let srcContractId: string;
   let owner: JWKInterface;
   let ownerAddress: string;
@@ -25,7 +25,7 @@ describe('Vaults', () => {
     srcContractId = getLocalArNSContractKey('id');
     owner = getLocalWallet(0);
     ownerAddress = await arweave.wallets.getAddress(owner);
-    contract = warp.pst(srcContractId).connect(owner);
+    contract = warp.contract<IOState>(srcContractId).connect(owner);
   });
 
   describe('createVault', () => {
@@ -165,7 +165,7 @@ describe('Vaults', () => {
 
     beforeAll(async () => {
       owner = getLocalWallet(0);
-      contract = warp.pst(srcContractId).connect(owner);
+      contract = warp.contract<IOState>(srcContractId).connect(owner);
     });
 
     it('should be able to extend vault', async () => {


### PR DESCRIPTION
this PR

- Removes `settings` from our contract state and uses constants in the code instead
- Updates test expectations to use constant settings instead of injectable settings