### PR TITLE
fix(PE-5558): reserverd short name purchases

### DIFF
--- a/schemas/buyRecord.js
+++ b/schemas/buyRecord.js
@@ -2,10 +2,6 @@ const buyRecordSchema = {
   $id: '#/definitions/buyRecord',
   type: 'object',
   properties: {
-    function: {
-      type: 'string',
-      const: 'buyRecord',
-    },
     name: {
       type: 'string',
       pattern: '^([a-zA-Z0-9][a-zA-Z0-9-]{0,49}[a-zA-Z0-9]|[a-zA-Z0-9]{1})$',
@@ -27,7 +23,7 @@ const buyRecordSchema = {
       type: 'boolean',
     },
   },
-  required: ['name', 'function'],
+  required: ['name'],
   additionalProperties: true, // allows for auction properties to be provided to buy record
 };
 

--- a/src/actions/read/price.ts
+++ b/src/actions/read/price.ts
@@ -67,6 +67,8 @@ export function getPriceForInteraction(
         records: state.records,
         reserved: state.reserved,
         currentBlockTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+        type,
+        auction,
       });
       fee = calculateRegistrationFee({
         name,
@@ -79,7 +81,7 @@ export function getPriceForInteraction(
       break;
     }
     case 'submitAuctionBid': {
-      const { name } = new AuctionBid(parsedInput);
+      const { name, type } = new AuctionBid(parsedInput);
       const auction = state.auctions[name];
       assertAvailableRecord({
         caller,
@@ -87,6 +89,8 @@ export function getPriceForInteraction(
         records: state.records,
         reserved: state.reserved,
         currentBlockTimestamp: new BlockTimestamp(+SmartWeave.block.timestamp),
+        type,
+        auction: true,
       });
       // return the floor price to start the auction
       if (!auction) {

--- a/src/actions/write/buyRecord.test.ts
+++ b/src/actions/write/buyRecord.test.ts
@@ -31,6 +31,7 @@ describe('buyRecord', () => {
         },
       });
       expect(state.records[reservedName]).toBeDefined();
+      expect(state.reserved[reservedName]).toBeUndefined();
     },
   );
 
@@ -58,6 +59,7 @@ describe('buyRecord', () => {
         },
       });
       expect(state.records[reservedName]).toBeDefined();
+      expect(state.reserved[reservedName]).toBeUndefined();
     },
   );
 

--- a/src/actions/write/buyRecord.test.ts
+++ b/src/actions/write/buyRecord.test.ts
@@ -1,0 +1,90 @@
+import { getBaselineState, stubbedArweaveTxId } from '../../tests/stubs';
+import { buyRecord } from './buyRecord';
+
+describe('buyRecord', () => {
+  it.each([
+    ['a', 'lease'],
+    ['a', 'permabuy'],
+    ['long-name', 'lease'],
+    ['long-name', 'permabuy'],
+  ])(
+    'should be able to buy a record of a reserved name when the caller is the target of the reserved name when it is a ',
+    async (reservedName: string, type: 'permabuy' | 'lease') => {
+      const initialState = {
+        ...getBaselineState(),
+        balances: {
+          caller: 10_000_000_000,
+        },
+        reserved: {
+          [reservedName]: {
+            target: 'caller',
+            endTimestamp: SmartWeave.block.timestamp + 1000, // some time in the future
+          },
+        },
+      };
+      const { state } = await buyRecord(initialState, {
+        caller: 'caller',
+        input: {
+          name: reservedName,
+          type,
+          contractTxId: stubbedArweaveTxId,
+        },
+      });
+      expect(state.records[reservedName]).toBeDefined();
+    },
+  );
+
+  it.each([['a-expired-reserved-name', 'not-short-name', 'reserved']])(
+    'should be able to buy a record of a reserved name when the caller is the target of the reserved name',
+    async (reservedName: string) => {
+      const initialState = {
+        ...getBaselineState(),
+        balances: {
+          ['non-reserved-caller']: 10_000_000_000,
+        },
+        reserved: {
+          [reservedName]: {
+            target: 'caller',
+            endTimestamp: 0, // expired!
+          },
+        },
+      };
+      const { state } = await buyRecord(initialState, {
+        caller: 'non-reserved-caller',
+        input: {
+          name: reservedName,
+          type: 'permabuy',
+          contractTxId: stubbedArweaveTxId,
+        },
+      });
+      expect(state.records[reservedName]).toBeDefined();
+    },
+  );
+
+  it.each([['a', 'test', 'reserved', 'name']])(
+    'should not be able to buy a record of a reserved name when the caller is not the target target of the reserved name',
+    async (reservedName: string) => {
+      const initialState = {
+        ...getBaselineState(),
+        balances: {
+          'non-reserved-caller': 10_000_000_000,
+        },
+        reserved: {
+          [reservedName]: {
+            target: 'non-reserved-caller',
+            endTimestamp: SmartWeave.block.timestamp + 1000, // some time in the future
+          },
+        },
+      };
+      const error = await buyRecord(initialState, {
+        caller: 'caller',
+        input: {
+          name: reservedName,
+          type: 'lease',
+          contractTxId: stubbedArweaveTxId,
+        },
+      }).catch((e) => e);
+      expect(error).toBeInstanceOf(Error);
+    },
+  );
+});

--- a/src/actions/write/buyRecord.ts
+++ b/src/actions/write/buyRecord.ts
@@ -1,7 +1,5 @@
-import { isNameRequiredToBeAuction } from '../../auctions';
 import {
   ARNS_NAME_IN_AUCTION_MESSAGE,
-  ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE,
   DEFAULT_UNDERNAME_COUNT,
   RESERVED_ATOMIC_TX_ID,
   SECONDS_IN_A_YEAR,
@@ -56,10 +54,10 @@ export class BuyRecord {
   }
 }
 
-export const buyRecord = (
+export const buyRecord = async (
   state: IOState,
   { caller, input }: PstAction,
-): ContractWriteResult => {
+): Promise<ContractWriteResult> => {
   // get all other relevant state data
   const { balances, records, reserved, fees, auctions } = state;
   const { name, contractTxId, years, type, auction } = new BuyRecord(input); // does validation on constructor
@@ -84,11 +82,9 @@ export const buyRecord = (
     records,
     reserved,
     currentBlockTimestamp,
+    type,
+    auction,
   });
-
-  if (isNameRequiredToBeAuction({ name, type })) {
-    throw new ContractError(ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE);
-  }
 
   const totalRegistrationFee = calculateRegistrationFee({
     name,

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -85,6 +85,8 @@ export const submitAuctionBid = (
     records: state.records,
     reserved: state.reserved,
     currentBlockTimestamp,
+    type: auctionBid.type,
+    auction: true,
   });
 
   // existing auction, handle the bid

--- a/src/records.ts
+++ b/src/records.ts
@@ -1,6 +1,8 @@
+import { isNameRequiredToBeAuction } from './auctions';
 import {
   ARNS_INVALID_SHORT_NAME,
   ARNS_LEASE_LENGTH_MAX_YEARS,
+  ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE,
   ARNS_NAME_RESERVED_MESSAGE,
   ARNS_NON_EXPIRED_NAME_MESSAGE,
   MINIMUM_ALLOWED_NAME_LENGTH,
@@ -117,10 +119,13 @@ export function isActiveReservedName({
   if (permanentlyReserved) {
     return true;
   }
-  const callerNotTarget = !caller || target !== caller;
-  const notExpired =
+
+  const isCallerTarget = caller !== undefined && target === caller;
+  const isActiveReservation =
     endTimestamp && endTimestamp > currentBlockTimestamp.valueOf();
-  if (callerNotTarget && notExpired) {
+
+  // if the caller is not the target, and it's still active - the name is considered reserved
+  if (!isCallerTarget && isActiveReservation) {
     return true;
   }
   return false;
@@ -132,33 +137,51 @@ export function assertAvailableRecord({
   records,
   reserved,
   currentBlockTimestamp,
+  type,
+  auction,
 }: {
   caller: string | undefined; // TODO: type for this
   name: DeepReadonly<string>;
   records: DeepReadonly<Records>;
   reserved: DeepReadonly<ReservedNames>;
   currentBlockTimestamp: BlockTimestamp;
+  type: 'permabuy' | 'lease';
+  auction: boolean;
 }): void {
-  if (
-    isExistingActiveRecord({
-      record: records[name],
-      currentBlockTimestamp,
-    })
-  ) {
+  const isActiveRecord = isExistingActiveRecord({
+    record: records[name],
+    currentBlockTimestamp,
+  });
+  const isReserved = isActiveReservedName({
+    caller,
+    reservedName: reserved[name],
+    currentBlockTimestamp,
+  });
+  const isShortName = isShortNameRestricted({
+    name,
+    currentBlockTimestamp,
+  });
+  const isAuctionRequired = isNameRequiredToBeAuction({ name, type });
+  if (isActiveRecord) {
     throw new ContractError(ARNS_NON_EXPIRED_NAME_MESSAGE);
   }
-  if (
-    isActiveReservedName({
-      caller,
-      reservedName: reserved[name],
-      currentBlockTimestamp,
-    })
-  ) {
+
+  if (reserved[name]?.target === caller) {
+    // if the caller is the target of the reserved name, they can buy it
+    return;
+  }
+
+  if (isReserved) {
     throw new ContractError(ARNS_NAME_RESERVED_MESSAGE);
   }
 
-  if (isShortNameRestricted({ name, currentBlockTimestamp })) {
+  if (isShortName) {
     throw new ContractError(ARNS_INVALID_SHORT_NAME);
+  }
+
+  // TODO: we may want to move this up if we want to force permabuys for short names on reserved names
+  if (isAuctionRequired && !auction) {
+    throw new ContractError(ARNS_NAME_MUST_BE_AUCTIONED_MESSAGE);
   }
 }
 


### PR DESCRIPTION
There is a bug where short names that are reserved cannot actually be purchased due to them being short names. This changes it so any reserved name called by the target can purchase the name. We may want to require an auction to be started if they are requesting a permabuy, will put that in a separate PR