### PR TITLE
fix(PE-5562): bug in distributions where nextDistributionHeight…

### DIFF
--- a/src/actions/write/tick.test.ts
+++ b/src/actions/write/tick.test.ts
@@ -1060,7 +1060,7 @@ describe('tick', () => {
   });
 
   // top level tests
-  it('should tick distributions for update gateway performance stats and increment the nextDistributionHeight if a the interaction height is equal to the nextDistributionHeight', async () => {
+  it('should tick distributions for the previous epoch, update gateway performance stats and increment the nextDistributionHeight if a the interaction height is equal to the nextDistributionHeight', async () => {
     const initialState: IOState = {
       ...getBaselineState(),
       gateways: stubbedGateways,

--- a/src/actions/write/tick.test.ts
+++ b/src/actions/write/tick.test.ts
@@ -954,7 +954,7 @@ describe('tick', () => {
     expect(gateways).toEqual(expectedGateways);
   });
 
-  it('should distribute rewards to observers who submitted reports and gateways who passed, update distribution epoch values and increment performance stats', async () => {
+  it('should distribute rewards to observers who submitted reports and gateways who passed for the previous epoch, update distribution epoch values and increment performance stats', async () => {
     const initialState: IOState = {
       ...getBaselineState(),
       balances: {
@@ -976,6 +976,12 @@ describe('tick', () => {
             // gateway-2 did not submit a report
           },
         },
+      },
+      distributions: {
+        ...getBaselineState().distributions,
+        // setting these to next epoch values to validate distributions depend on only the nextDistributionHeight
+        epochEndHeight: SmartWeave.block.height + 2 * EPOCH_BLOCK_LENGTH - 1,
+        epochStartHeight: SmartWeave.block.height + EPOCH_BLOCK_LENGTH - 1,
       },
     };
     const nextDistributionHeight =
@@ -1054,7 +1060,7 @@ describe('tick', () => {
   });
 
   // top level tests
-  it('should tick distributions, update gateway performance stats and increment the nextDistributionHeight if a the interaction height is equal to the nextDistributionHeight', async () => {
+  it('should tick distributions for update gateway performance stats and increment the nextDistributionHeight if a the interaction height is equal to the nextDistributionHeight', async () => {
     const initialState: IOState = {
       ...getBaselineState(),
       gateways: stubbedGateways,

--- a/src/actions/write/tick.ts
+++ b/src/actions/write/tick.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GATEWAY_PERFORMANCE_STATS,
   DEFAULT_UNDERNAME_COUNT,
   EPOCH_BLOCK_LENGTH,
+  EPOCH_DISTRIBUTION_DELAY,
   EPOCH_REWARD_PERCENTAGE,
   GATEWAY_PERCENTAGE_OF_EPOCH_REWARD,
   GATEWAY_REGISTRY_SETTINGS,
@@ -461,9 +462,14 @@ export async function tickRewardDistribution({
     };
   }
 
-  // get our epoch heights
-  const epochStartHeight = new BlockHeight(distributions.epochStartHeight);
-  const epochEndHeight = new BlockHeight(distributions.epochEndHeight);
+  // get our epoch heights based off the distribution end height
+  const { epochStartHeight, epochEndHeight } = getEpochDataForHeight({
+    currentBlockHeight: new BlockHeight(
+      distributionHeightForLastEpoch.valueOf() - EPOCH_DISTRIBUTION_DELAY - 1,
+    ),
+    epochZeroStartHeight: new BlockHeight(distributions.epochZeroStartHeight),
+    epochBlockLength: new BlockHeight(EPOCH_BLOCK_LENGTH),
+  });
 
   // get all the reports submitted for the epoch based on its start height
   const totalReportsSubmitted = Object.keys(


### PR DESCRIPTION
… is not being used when determining epoch start and end height for the previous epoch. This prevented a distribution from occurring bc the `epochStartHeight` and `endHeight` were updated at the end of the epoch. When the `nextDistributionHeight` was reached, it used these update `epochStartHeight` and `epochEndHeight` values to determine what distributions should go out.