### PR TITLE
fix(update): allow `observerWallet` to be provided if it matches the …

### DIFF
--- a/src/actions/write/updateGatewaySettings.test.ts
+++ b/src/actions/write/updateGatewaySettings.test.ts
@@ -1,0 +1,82 @@
+import {
+  INVALID_INPUT_MESSAGE,
+  INVALID_OBSERVER_WALLET,
+} from '../../constants';
+import {
+  getBaselineState,
+  stubbedArweaveTxId,
+  stubbedGatewayData,
+} from '../../tests/stubs';
+import { updateGatewaySettings } from './updateGatewaySettings';
+
+describe('updateGatewaySettings', () => {
+  describe('invalid inputs', () => {
+    it.each([['bad-port', '0', 0, -1, true, Number.MAX_SAFE_INTEGER]])(
+      'should throw an error on invalid qty',
+      async (badQty: unknown) => {
+        const initialState = getBaselineState();
+        const error = await updateGatewaySettings(initialState, {
+          caller: 'test',
+          input: {
+            qty: badQty,
+            settings: {
+              port: badQty,
+            },
+          },
+        }).catch((e) => e);
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toEqual(
+          expect.stringContaining(INVALID_INPUT_MESSAGE),
+        );
+      },
+    );
+  });
+
+  describe('valid inputs', () => {
+    it('should fail if observerWallet is used by another gateway', async () => {
+      const initialState = {
+        ...getBaselineState(),
+        gateways: {
+          'a-gateway': stubbedGatewayData,
+          'a-gateway-2': {
+            ...stubbedGatewayData,
+            observerWallet: stubbedArweaveTxId,
+          },
+        },
+      };
+      const error = await updateGatewaySettings(initialState, {
+        caller: 'a-gateway',
+        input: {
+          observerWallet: stubbedArweaveTxId,
+        },
+      }).catch((e) => e);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toEqual(
+        expect.stringContaining(INVALID_OBSERVER_WALLET),
+      );
+    });
+
+    it('should not fail if observerWallet is used by the caller gateway', async () => {
+      const initialState = {
+        ...getBaselineState(),
+        gateways: {
+          'a-gateway': {
+            ...stubbedGatewayData,
+            observerWallet: stubbedArweaveTxId,
+          },
+          'a-gateway-2': {
+            ...stubbedGatewayData,
+            observerWallet: 'not-the-same-wallet',
+          },
+        },
+      };
+      const { state } = await updateGatewaySettings(initialState, {
+        caller: 'a-gateway',
+        input: {
+          observerWallet: stubbedArweaveTxId,
+        },
+      });
+      expect(state).toEqual(initialState);
+    });
+  });
+});

--- a/src/actions/write/updateGatewaySettings.ts
+++ b/src/actions/write/updateGatewaySettings.ts
@@ -2,7 +2,13 @@ import {
   INVALID_GATEWAY_REGISTERED_MESSAGE,
   INVALID_OBSERVER_WALLET,
 } from '../../constants';
-import { ContractWriteResult, IOState, PstAction } from '../../types';
+import {
+  ContractWriteResult,
+  Gateway,
+  IOState,
+  PstAction,
+  WalletAddress,
+} from '../../types';
 import { getInvalidAjvMessage } from '../../utilities';
 import { validateUpdateGateway } from '../../validations';
 
@@ -53,8 +59,10 @@ export const updateGatewaySettings = async (
   }
 
   if (
-    Object.values(gateways).some(
-      (gateway) => gateway.observerWallet === updatedObserverWallet,
+    Object.entries(gateways).some(
+      ([gatewayAddress, gateway]: [WalletAddress, Gateway]) =>
+        gateway.observerWallet === updatedObserverWallet &&
+        gatewayAddress !== caller,
     )
   ) {
     throw new ContractError(INVALID_OBSERVER_WALLET);


### PR DESCRIPTION
…callers observerWallet