### PR TITLE
chore(tools): add cli scripts for easier gateway operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ You can copy [.env.sample](./env.sample) to `.env` and fill in the values before
 
 ### CLI
 
+#### Operators
+
 - `yarn join-network` - [join-network] - takes a Gateway into the ar.io network and adds the Gateway into the Gateway Address Registry. This detail includes the Gateway Operator’s public wallet address, fully qualified domain name, port, protocol, properties and friendly note.
 
 ```shell
@@ -101,7 +103,7 @@ tem.","observerWallet":"IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs","allowDeleg
 
 ### Scripts
 
-### Arweave Name System (ArNS)
+#### Arweave Name System (ArNS)
 
 The following tools can be used to perform basic ArNS operations such as name purchase, ANT creation, and ANT transfer.
 
@@ -118,7 +120,7 @@ The following tools can be used to perform basic ArNS operations such as name pu
   yarn ts-node tools/buy-arns-name-atomic-ant.ts
   ```
 
-### AR.IO Testnet Network
+#### AR.IO Testnet Network
 
 The following tools can be used to perform basic AR.IO Network operations, such as joining and leaving the network, along with managing the onchain settings of a Gateway.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ You can copy [.env.sample](./env.sample) to `.env` and fill in the values before
 
 #### Operators
 
+- `yarn get-balance` - [get-balance] - get the balance of a wallet address.
+
+```shell
+❯ yarn get-balance
+? Enter the address you want to check the balance >  QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ
+Balance: 714667588.589208 IO
+```
+
 - `yarn join-network` - [join-network] - takes a Gateway into the ar.io network and adds the Gateway into the Gateway Address Registry. This detail includes the Gateway Operator’s public wallet address, fully qualified domain name, port, protocol, properties and friendly note.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ tem.","observerWallet":"IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs","allowDeleg
 ? CONFIRM DELEGATION DETAILS? {"target":"1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo","qty":100} > (Y/n)
 ```
 
+- `yarn increase-operator-stake` - [increase-operator-stake] - increase the token amount staked for an existing registered Gateway.
+
+```shell
+❯ yarn increase-operator-stake
+? Enter the additional operator stake amount in IO (current balance: 714667588.589208) IO >  100
+? CONFIRM INCREASE OPERATOR STAKE DETAILS? {"qty":100} > (Y/n)
+```
+
 ### Scripts
 
 #### Arweave Name System (ArNS)
@@ -138,12 +146,6 @@ The following tools can be used to perform basic AR.IO Network operations, such 
   yarn ts-node tools/transfer-tokens.ts
   ```
 
-- [increase-operator-stake] - increase the token amount staked for an existing registered Gateway.
-
-  ```shell
-  yarn ts-node tools/increase-operator-stake.ts
-  ```
-
 - [decrease-operator-stake] - decrease stake for an existing registered Gateway. Tokens are put into a vault and then returned to the gateway address after the specified duration.
 
   ```shell
@@ -165,7 +167,7 @@ The following tools can be used to perform basic AR.IO Network operations, such 
 [get-balance]: tools/cli/get-balance.ts
 [join-network]: tools/cli/join-network.ts
 [update-gateway-settings]: tools/cli/update-gateway-settings.ts
-[increase-operator-stake]: tools/increase-operator-stake.ts
+[increase-operator-stake]: tools/cli/increase-operator-stake.ts
 [decrease-operator-stake]: tools/decrease-operator-stake.ts
 [delegate-stake]: tools/cli/delegate-stake.ts
 [get-prescribed-observers]: tools/get-prescribed-observers.ts

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following tools can be used to perform basic AR.IO Network operations, such 
   yarn ts-node tools/leave-network.ts
   ```
 
+[get-balance]: tools/cli/get-balance.ts
 [join-network]: tools/cli/join-network.ts
 [update-gateway-settings]: tools/cli/update-gateway-settings.ts
 [increase-operator-stake]: tools/increase-operator-stake.ts

--- a/README.md
+++ b/README.md
@@ -51,6 +51,56 @@ You can also modify the script to use `dryWrite` following Warps documentation [
 
 You can copy [.env.sample](./env.sample) to `.env` and fill in the values before executing any scripts.
 
+### CLI
+
+- `yarn join-network` - [join-network] - takes a Gateway into the ar.io network and adds the Gateway into the Gateway Address Registry. This detail includes the Gateway Operator’s public wallet address, fully qualified domain name, port, protocol, properties and friendly note.
+
+```shell
+❯ yarn join-network
+? Enter your a friendly name for your gateway (e.g. Permagate) >  ArIO Gateway
+? Enter your domain for this gateway (e.g. <my-gateway>.com) >  ar-io.dev
+? Enter the amount of tokens you want to stake against your gateway (min 10,000 IO) >  10000
+? Enter port used for this gateway >  443
+? Enter protocol used for this gateway >  https
+? Enter gateway properties (optional - use default if not sure) >  FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44
+? Enter short note to further describe this gateway >  Operated by the ar.io team
+? Enter the observer wallet public address >  QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ
+? Enable or disable delegated staking? >  Yes
+? Enter the percent of gateway and observer rewards given to delegates >  25
+? Enter the minimum stake in IO a delegate must use for this for this gateway >  500
+? CONFIRM GATEWAY DETAILS? {"label":"ArIO Gateway","fqdn":"ar-io.dev","qty":10000,"port":443,"protocol":"https","properties":"FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44","note":"Operated by the ar.io team","observerWallet":"QGWqtJdLLgm2
+ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ","allowDelegatedStaking":true,"delegateRewardShareRatio":25,"minDelegatedStake":500} > (Y/n)
+```
+
+- `yarn update-gateway-settings` - [update-gateway-settings] - modify the settings of an existing registered Gateway record in the Gateway Address Registry, like the friendly name, fully qualified domain name, port, protocol, status, properties, and note.
+
+```shell
+❯ yarn update-gateway-settings
+? Enter your a friendly name for your gateway >  Test Gateway
+? Enter your domain for this gateway >  permanence-testing.org
+? Enter port used for this gateway >  443
+? Enter protocol used for this gateway >  https
+? Enter gateway properties (use default if not sure) >  raJgvbFU-YAnku-WsupIdbTsqqGLQiYpGzoqk9SCVgY
+? Enter short note to further describe this gateway >  Test Gateway operated by PDS for the AR.IO ecosystem.
+? Enter the observer wallet public address >  IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs
+? Enable or disable delegated staking? >  Yes
+? Enter the percent of gateway and observer rewards given to delegates >  30
+? Enter the minimum stake in IO a delegate must use for this for this gateway >  100000000
+? CONFIRM UPDATED GATEWAY DETAILS? {"label":"Test Gateway","fqdn":"permanence-testing.org","port":443,"protocol":"https","properties":"raJgvbFU-YAnku-WsupIdbTsqqGLQiYpGzoqk9SCVgY","note":"Test Gateway operated by PDS for the AR.IO ecosys
+tem.","observerWallet":"IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs","allowDelegatedStaking":true,"delegateRewardShareRatio":30,"minDelegatedStake":100000000} > Yes
+```
+
+- `yarn delegate-stake` - [delegate-stake] - delegate stake a to a gateway that allows delegation - you will receive rewards for their work - based on their delegation settings.
+
+```shell
+❯ yarn delegate-stake
+? Enter the target gateway you want to delegate to >  1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo
+? Enter Stake Quantity (in IO) >  100
+? CONFIRM DELEGATION DETAILS? {"target":"1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo","qty":100} > (Y/n)
+```
+
+### Scripts
+
 ### Arweave Name System (ArNS)
 
 The following tools can be used to perform basic ArNS operations such as name purchase, ANT creation, and ANT transfer.
@@ -78,28 +128,10 @@ The following tools can be used to perform basic AR.IO Network operations, such 
   yarn ts-node tools/transfer-tokens.ts
   ```
 
-- [join-network] - takes a Gateway into the ar.io network and adds the Gateway into the Gateway Address Registry. This detail includes the Gateway Operator’s public wallet address, fully qualified domain name, port, protocol, properties and friendly note.
-
-  ```shell
-  yarn ts-node tools/join-network.ts
-  ```
-
-- [update-gateway-settings] - modify the settings of an existing registered Gateway record in the Gateway Address Registry, like the friendly name, fully qualified domain name, port, protocol, status, properties, and note.
-
-  ```shell
-  yarn ts-node tools/update-gateway-settings.ts
-  ```
-
 - [increase-operator-stake] - increase the token amount staked for an existing registered Gateway.
 
   ```shell
   yarn ts-node tools/increase-operator-stake.ts
-  ```
-
-- [delegate-stake] - delegate stake a to a gateway that allows delegation - you will receive rewards for their work - based on their delegation settings.
-
-  ```shell
-  yarn ts-node tools/delegate-stake.ts
   ```
 
 - [decrease-operator-stake] - decrease stake for an existing registered Gateway. Tokens are put into a vault and then returned to the gateway address after the specified duration.
@@ -120,11 +152,11 @@ The following tools can be used to perform basic AR.IO Network operations, such 
   yarn ts-node tools/leave-network.ts
   ```
 
-[join-network]: tools/join-network.ts
-[update-gateway-settings]: tools/update-gateway-settings.ts
+[join-network]: tools/cli/join-network.ts
+[update-gateway-settings]: tools/cli/update-gateway-settings.ts
 [increase-operator-stake]: tools/increase-operator-stake.ts
 [decrease-operator-stake]: tools/decrease-operator-stake.ts
-[delegate-stake]: tools/delegate-stake.ts
+[delegate-stake]: tools/cli/delegate-stake.ts
 [get-prescribed-observers]: tools/get-prescribed-observers.ts
 [leave-network]: tools/leave-network.ts
 [buy-arns-name]: tools/buy-arns-name.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
   setupFilesAfterEnv: ['./tests/mocks.jest.ts'],
   testMatch: ['**/src/**/*.test.ts'],
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts/**'],
   testEnvironment: 'node',
   testTimeout: 60_000,
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|js)$': 'ts-jest',
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
   setupFilesAfterEnv: ['./tests/mocks.jest.ts'],
   testMatch: ['**/src/**/*.test.ts'],
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts', '!src/tests/**'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
   testEnvironment: 'node',
   testTimeout: 60_000,
   transform: {
-    '^.+\\.(ts|js)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': 'ts-jest',
   },
 };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -8,6 +8,6 @@ module.exports = {
   testEnvironment: 'node',
   testTimeout: 60_000,
   transform: {
-    '^.+\\.(ts|js)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': 'ts-jest',
   },
 };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -8,6 +8,6 @@ module.exports = {
   testEnvironment: 'node',
   testTimeout: 60_000,
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|js)$': 'ts-jest',
   },
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "join-network": "yarn ts-node ./tools/cli/join-network.ts",
     "delegate-stake": "yarn ts-node ./tools/cli/delegate-stake.ts",
     "update-gateway-settings": "yarn ts-node ./tools/cli/update-gateway-settings.ts",
-    "get-balance": "yarn ts-node ./tools/cli/get-balance.ts"
+    "get-balance": "yarn ts-node ./tools/cli/get-balance.ts",
+    "increase-operator-stake": "yarn ts-node ./tools/cli/increase-operator-stake.ts"
   },
   "devDependencies": {
     "@ar.io/sdk": "alpha",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,13 @@
     "evolve:state": "yarn ts-node ./tools/evolve-state.ts",
     "tick": "yarn ts-node ./tools/tick.ts",
     "prepare": "husky install",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "join-network": "yarn ts-node ./tools/cli/join-network.ts",
+    "delegate-stake": "yarn ts-node ./tools/cli/delegate-stake.ts",
+    "update-gateway-settings": "yarn ts-node ./tools/cli/update-gateway-settings.ts"
   },
   "devDependencies": {
+    "@ar.io/sdk": "alpha",
     "@commitlint/config-conventional": "^17.7.0",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/jest": "^27.4.0",
@@ -35,6 +39,7 @@
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "husky": "^8.0.3",
+    "inquirer": "8.0.0",
     "jest": "^27.4.3",
     "jest-junit": "^16.0.0",
     "lint-staged": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pre-commit": "lint-staged",
     "join-network": "yarn ts-node ./tools/cli/join-network.ts",
     "delegate-stake": "yarn ts-node ./tools/cli/delegate-stake.ts",
-    "update-gateway-settings": "yarn ts-node ./tools/cli/update-gateway-settings.ts"
+    "update-gateway-settings": "yarn ts-node ./tools/cli/update-gateway-settings.ts",
+    "get-balance": "yarn ts-node ./tools/cli/get-balance.ts"
   },
   "devDependencies": {
     "@ar.io/sdk": "alpha",

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -1,17 +1,37 @@
-import { Contract, JWKInterface } from 'warp-contracts';
+import Arweave from 'arweave';
+import {
+  Contract,
+  JWKInterface,
+  WarpFactory,
+  defaultCacheOptions,
+} from 'warp-contracts';
+import { DeployPlugin } from 'warp-contracts-plugin-deploy';
 
 import { IOState } from '../src/types';
 import {
-  arweave,
   getContractManifest,
-  warp as warpMainnet,
-} from '../tools/utilities';
-import { getLocalArNSContractKey, getLocalWallet } from './utils/helper';
+  getLocalArNSContractKey,
+  getLocalWallet,
+} from './utils/helper';
 import { arweave as arweaveLocal, warp as warpLocal } from './utils/services';
 
 const testnetContractTxId =
   process.env.ARNS_CONTRACT_TX_ID ??
   'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
+const arweave = new Arweave({
+  host: 'ar-io.dev',
+  port: 443,
+  protocol: 'https',
+});
+
+const warpMainnet = WarpFactory.forMainnet(
+  {
+    ...defaultCacheOptions,
+  },
+  true,
+  arweave,
+).use(new DeployPlugin());
 
 describe('evolving', () => {
   let localContractOwnerJWK: JWKInterface;

--- a/tools/buy-arns-name-atomic-ant.ts
+++ b/tools/buy-arns-name-atomic-ant.ts
@@ -1,7 +1,13 @@
 import { JWKInterface } from 'arweave/node/lib/wallet';
 import { Tag } from 'warp-contracts';
 
-import { arweave, initialize, loadWallet, warp } from './utilities';
+import {
+  arnsContractTxId,
+  arweave,
+  initialize,
+  loadWallet,
+  warp,
+} from './utilities';
 
 /* eslint-disable no-console */
 (async () => {
@@ -20,11 +26,6 @@ import { arweave, initialize, loadWallet, warp } from './utilities';
 
   // load local wallet
   const wallet: JWKInterface = loadWallet();
-
-  // load state of contract
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/buy-arns-name.ts
+++ b/tools/buy-arns-name.ts
@@ -1,5 +1,11 @@
 import { IOState } from '../src/types';
-import { getContractManifest, initialize, loadWallet, warp } from './utilities';
+import {
+  arnsContractTxId,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from './utilities';
 
 /* eslint-disable no-console */
 (async () => {
@@ -20,11 +26,6 @@ import { getContractManifest, initialize, loadWallet, warp } from './utilities';
 
   // load local wallet
   const wallet = loadWallet();
-
-  // load state of contract
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'E-pRI1bokGWQBqHnbut9rsHSt9Ypbldos3bAtwg4JMc';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/delegate-stake.ts
+++ b/tools/cli/delegate-stake.ts
@@ -60,7 +60,7 @@ import questions from './questions';
     });
     // eslint-disable-next-line;
     console.log(
-      `Successfully submitted request to join the network. TxId: ${txId?.originalTxId}`,
+      `Successfully submitted request to delegate stake. TxId: ${txId?.originalTxId}`,
     );
   }
 })();

--- a/tools/cli/delegate-stake.ts
+++ b/tools/cli/delegate-stake.ts
@@ -1,0 +1,70 @@
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import inquirer from 'inquirer';
+
+import { IOState } from '../../src/types';
+import {
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from '../utilities';
+import questions from './questions';
+
+(async () => {
+  // simple setup script
+  initialize();
+
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = loadWallet();
+
+  const gatewayDetails = await inquirer.prompt(questions.delegateStake());
+
+  // gate the contract txId
+  const arnsContractTxId =
+    process.env.ARNS_CONTRACT_TX_ID ??
+    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
+  // get contract manifest
+  const { evaluationOptions = {} } = await getContractManifest({
+    contractTxId: arnsContractTxId,
+  });
+
+  // Connect the ArNS Registry Contract
+  const contract = await warp
+    .contract<IOState>(arnsContractTxId)
+    .connect(wallet)
+    .setEvaluationOptions(evaluationOptions)
+    .syncState(`https://api.arns.app/v1/contract/${arnsContractTxId}`, {
+      validity: true,
+    });
+
+  const confirm = await inquirer.prompt({
+    name: 'confirm',
+    type: 'confirm',
+    message: `CONFIRM DELEGATION DETAILS? ${JSON.stringify(gatewayDetails)} >`,
+  });
+
+  if (confirm.confirm) {
+    const payload = {
+      function: 'delegateStake',
+      target: gatewayDetails.target,
+      qty: gatewayDetails.qty,
+    };
+    const dryWrite = await contract.dryWrite(payload);
+
+    if (dryWrite.type === 'error' || dryWrite.errorMessage) {
+      console.error('Failed to delegate stake:', dryWrite.errorMessage);
+      return;
+    }
+
+    console.log('Submitting transaction to delegate stake...');
+
+    const txId = await contract.writeInteraction(payload, {
+      disableBundling: true,
+    });
+    // eslint-disable-next-line;
+    console.log(
+      `Successfully submitted request to join the network. TxId: ${txId?.originalTxId}`,
+    );
+  }
+})();

--- a/tools/cli/delegate-stake.ts
+++ b/tools/cli/delegate-stake.ts
@@ -4,9 +4,11 @@ import inquirer from 'inquirer';
 import { IOState } from '../../src/types';
 import {
   arnsContractTxId,
+  arweave,
   getContractManifest,
   initialize,
   loadWallet,
+  networkContract,
   warp,
 } from '../utilities';
 import questions from './questions';
@@ -18,7 +20,15 @@ import questions from './questions';
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
 
-  const gatewayDetails = await inquirer.prompt(questions.delegateStake());
+  const walletAddress = await arweave.wallets.jwkToAddress(wallet);
+
+  const balance = await networkContract.getBalance({
+    address: walletAddress,
+  });
+
+  const gatewayDetails = await inquirer.prompt(
+    questions.delegateStake(balance / 1000000),
+  );
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/delegate-stake.ts
+++ b/tools/cli/delegate-stake.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 
 import { IOState } from '../../src/types';
 import {
+  arnsContractTxId,
   getContractManifest,
   initialize,
   loadWallet,
@@ -18,9 +19,6 @@ import questions from './questions';
   const wallet: JWKInterface = loadWallet();
 
   const gatewayDetails = await inquirer.prompt(questions.delegateStake());
-
-  // gate the contract txId
-  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/delegate-stake.ts
+++ b/tools/cli/delegate-stake.ts
@@ -20,9 +20,7 @@ import questions from './questions';
   const gatewayDetails = await inquirer.prompt(questions.delegateStake());
 
   // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/get-balance.ts
+++ b/tools/cli/get-balance.ts
@@ -1,0 +1,51 @@
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import inquirer from 'inquirer';
+
+import { IOState } from '../../src/types';
+import {
+  arnsContractTxId,
+  arweave,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from '../utilities';
+import questions from './questions';
+
+(async () => {
+  // simple setup script
+  initialize();
+
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = loadWallet();
+
+  const address = await arweave.wallets.jwkToAddress(wallet);
+
+  const gatewayDetails = await inquirer.prompt(questions.getBalance(address));
+
+  // get contract manifest
+  const { evaluationOptions = {} } = await getContractManifest({
+    contractTxId: arnsContractTxId,
+  });
+
+  // Connect the ArNS Registry Contract
+  const contract = await warp
+    .contract<IOState>(arnsContractTxId)
+    .connect(wallet)
+    .setEvaluationOptions(evaluationOptions)
+    .syncState(`https://api.arns.app/v1/contract/${arnsContractTxId}`, {
+      validity: true,
+    });
+
+  const payload = {
+    function: 'balance',
+    target: gatewayDetails.address,
+  };
+
+  const { result } = await contract.viewState<
+    { function: string; target: string },
+    { address: string; balance: number }
+  >(payload);
+  // eslint-disable-next-line;
+  console.log(`Balance: ${result.balance / 1_000_000} IO`);
+})();

--- a/tools/cli/increase-operator-stake.ts
+++ b/tools/cli/increase-operator-stake.ts
@@ -1,0 +1,80 @@
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import inquirer from 'inquirer';
+
+import { IOState } from '../../src/types';
+import {
+  arnsContractTxId,
+  arweave,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  networkContract,
+  warp,
+} from '../utilities';
+import questions from './questions';
+
+(async () => {
+  // simple setup script
+  initialize();
+
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = loadWallet();
+
+  const walletAddress = await arweave.wallets.jwkToAddress(wallet);
+
+  const mIOBalance: number = await networkContract.getBalance({
+    address: walletAddress,
+  });
+
+  const gatewayDetails = await inquirer.prompt(
+    questions.increaseOperatorStake(mIOBalance / 1000000),
+  );
+
+  // get contract manifest
+  const { evaluationOptions = {} } = await getContractManifest({
+    contractTxId: arnsContractTxId,
+  });
+
+  // Connect the ArNS Registry Contract
+  const contract = await warp
+    .contract<IOState>(arnsContractTxId)
+    .connect(wallet)
+    .setEvaluationOptions(evaluationOptions)
+    .syncState(`https://api.arns.app/v1/contract/${arnsContractTxId}`, {
+      validity: true,
+    });
+
+  const confirm = await inquirer.prompt({
+    name: 'confirm',
+    type: 'confirm',
+    message: `CONFIRM INCREASE OPERATOR STAKE DETAILS? ${JSON.stringify(
+      gatewayDetails,
+    )} >`,
+  });
+
+  if (confirm.confirm) {
+    const payload = {
+      function: 'increaseOperatorStake',
+      qty: gatewayDetails.qty,
+    };
+    const dryWrite = await contract.dryWrite(payload);
+
+    if (dryWrite.type === 'error' || dryWrite.errorMessage) {
+      console.error(
+        'Failed to increase operator stake:',
+        dryWrite.errorMessage,
+      );
+      return;
+    }
+
+    console.log('Submitting transaction to increase operator stake...');
+
+    const txId = await contract.writeInteraction(payload, {
+      disableBundling: true,
+    });
+    // eslint-disable-next-line;
+    console.log(
+      `Successfully submitted request to increase operator stake. TxId: ${txId?.originalTxId}`,
+    );
+  }
+})();

--- a/tools/cli/join-network.ts
+++ b/tools/cli/join-network.ts
@@ -1,0 +1,96 @@
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import inquirer from 'inquirer';
+
+import { IOState } from '../../src/types';
+import {
+  arweave,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from '../utilities';
+import questions from './questions';
+
+(async () => {
+  // simple setup script
+  initialize();
+
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = loadWallet();
+
+  const walletAddress = await arweave.wallets.jwkToAddress(wallet);
+
+  const gatewayDetails = await inquirer.prompt(
+    questions.gatewaySettings(walletAddress),
+  );
+
+  // gate the contract txId
+  const arnsContractTxId =
+    process.env.ARNS_CONTRACT_TX_ID ??
+    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
+  // get contract manifest
+  const { evaluationOptions = {} } = await getContractManifest({
+    contractTxId: arnsContractTxId,
+  });
+
+  // Connect the ArNS Registry Contract
+  const contract = await warp
+    .contract<IOState>(arnsContractTxId)
+    .connect(wallet)
+    .setEvaluationOptions(evaluationOptions)
+    .syncState(`https://api.arns.app/v1/contract/${arnsContractTxId}`, {
+      validity: true,
+    });
+
+  const confirm = await inquirer.prompt({
+    name: 'confirm',
+    type: 'confirm',
+    message: `CONFIRM GATEWAY DETAILS? ${JSON.stringify(gatewayDetails)} >`,
+  });
+
+  if (confirm.confirm) {
+    const payload = {
+      function: 'joinNetwork',
+      ...(gatewayDetails.observerWallet
+        ? { observerWallet: gatewayDetails.observerWallet }
+        : {}),
+      ...(gatewayDetails.allowDelegatedStaking
+        ? { allowDelegatedStaking: gatewayDetails.allowDelegatedStaking }
+        : {}),
+      ...(gatewayDetails.delegateRewardShareRatio
+        ? {
+            delegateRewardShareRatio: gatewayDetails.delegateRewardShareRatio,
+          }
+        : {}),
+      ...(gatewayDetails.minDelegatedStake
+        ? { minDelegatedStake: gatewayDetails.minDelegatedStake }
+        : {}),
+      ...(gatewayDetails.note ? { note: gatewayDetails.note } : {}),
+      ...(gatewayDetails.properties
+        ? { properties: gatewayDetails.properties }
+        : {}),
+      ...(gatewayDetails.protocol ? { protocol: gatewayDetails.protocol } : {}),
+      ...(gatewayDetails.port ? { port: gatewayDetails.port } : {}),
+      ...(gatewayDetails.fqdn ? { fqdn: gatewayDetails.fqdn } : {}),
+      ...(gatewayDetails.label ? { label: gatewayDetails.label } : {}),
+      ...(gatewayDetails.qty ? { qty: gatewayDetails.qty } : {}),
+    };
+    const dryWrite = await contract.dryWrite(payload);
+
+    if (dryWrite.type === 'error' || dryWrite.errorMessage) {
+      console.error('Failed to join network:', dryWrite.errorMessage);
+      return;
+    }
+
+    console.log('Submitting transaction to join network...');
+
+    const txId = await contract.writeInteraction(payload, {
+      disableBundling: true,
+    });
+    // eslint-disable-next-line
+    console.log(
+      `Successfully submitted request to join the network. TxId: ${txId?.originalTxId}`,
+    );
+  }
+})();

--- a/tools/cli/join-network.ts
+++ b/tools/cli/join-network.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 
 import { IOState } from '../../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -23,9 +24,6 @@ import questions from './questions';
   const gatewayDetails = await inquirer.prompt(
     questions.gatewaySettings(walletAddress),
   );
-
-  // gate the contract txId
-  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/join-network.ts
+++ b/tools/cli/join-network.ts
@@ -25,9 +25,7 @@ import questions from './questions';
   );
 
   // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -125,6 +125,21 @@ export default {
     ];
     return questionList;
   },
+  increaseOperatorStake: (balance?: number): QuestionCollection => {
+    const questionList: QuestionCollection = [
+      {
+        name: 'qty',
+        type: 'number',
+        message: `Enter the additional operator stake amount in IO (current balance: ${
+          balance || 0
+        }) IO > `,
+        default: 100,
+        validate: (value: number) =>
+          value > 0 ? true : 'Please Enter Valid Amount',
+      },
+    ];
+    return questionList;
+  },
   delegateStake: (): QuestionCollection => {
     const questionList: QuestionCollection = [
       {

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -1,6 +1,8 @@
 import { Gateway } from '@ar.io/sdk';
 import { QuestionCollection } from 'inquirer';
 
+import { isArweaveAddress } from '../utilities';
+
 export default {
   gatewaySettings: (
     address?: string,
@@ -61,12 +63,13 @@ export default {
       {
         name: 'properties',
         type: 'input',
-        message: 'Enter gateway properties (use default if not sure) > ',
+        message:
+          'Enter gateway properties transaction ID (use default if not sure) > ',
         default: gateway
           ? gateway.settings.properties
           : 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
         validate: (value: string) =>
-          value.length === 43 ? true : 'Please Enter Valid Properties',
+          isArweaveAddress(value) ? true : 'Please Enter Valid Address',
       },
       {
         name: 'note',
@@ -116,7 +119,7 @@ export default {
         type: 'input',
         message: 'Enter the target gateway you want to delegate to > ',
         validate: (value: string) =>
-          value.length === 43 ? true : 'Please Enter Valid Gateway Address',
+          isArweaveAddress(value) ? true : 'Please Enter Valid Address',
       },
       {
         name: 'qty',

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -117,7 +117,7 @@ export default {
       {
         name: 'target',
         type: 'input',
-        message: 'Enter the target gateway you want to delegate to > ',
+        message: 'Enter the target gateway address you want to delegate to > ',
         validate: (value: string) =>
           isArweaveAddress(value) ? true : 'Please Enter Valid Address',
       },

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -132,7 +132,7 @@ export default {
         type: 'number',
         message: `Enter the additional operator stake amount in IO (current balance: ${
           balance || 0
-        }) IO > `,
+        } IO) > `,
         default: 100,
         validate: (value: number) =>
           value > 0 ? true : 'Please Enter Valid Amount',

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -135,12 +135,14 @@ export default {
         } IO) > `,
         default: 100,
         validate: (value: number) =>
-          value > 0 ? true : 'Please Enter Valid Amount',
+          value > 0 && (balance ? value <= balance : true)
+            ? true
+            : 'Please Enter Valid Amount',
       },
     ];
     return questionList;
   },
-  delegateStake: (): QuestionCollection => {
+  delegateStake: (balance?: number): QuestionCollection => {
     const questionList: QuestionCollection = [
       {
         name: 'target',
@@ -152,10 +154,12 @@ export default {
       {
         name: 'qty',
         type: 'number',
-        message: 'Enter Stake Quantity (in IO) > ',
+        message: `Enter stake quantity (current balance: ${balance || 0})  > `,
         default: 100,
         validate: (value: number) =>
-          value > 0 ? true : 'Please Enter Valid Amount',
+          value > 0 && (balance ? value <= balance : true)
+            ? true
+            : 'Please Enter Valid Amount',
       },
     ];
     return questionList;

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -104,12 +104,25 @@ export default {
         name: 'minDelegatedStake',
         type: 'number',
         message:
-          'Enter the minimum stake in IO a delegate must use for this for this gateway > ',
+          'Enter the minimum  delegate stake for this gateway (in IO) > ',
         default: gateway ? gateway.settings.minDelegatedStake : 100,
         validate: (value: number) =>
           value > 0 ? true : 'Please Enter Valid Amount',
       },
     ].filter((question) => !!question);
+    return questionList;
+  },
+  getBalance: (address?: string): QuestionCollection => {
+    const questionList: QuestionCollection = [
+      {
+        name: 'address',
+        type: 'input',
+        message: 'Enter the address you want to check the balance > ',
+        default: address ? address : '',
+        validate: (value: string) =>
+          isArweaveAddress(value) ? true : 'Please Enter Valid Address',
+      },
+    ];
     return questionList;
   },
   delegateStake: (): QuestionCollection => {

--- a/tools/cli/questions.ts
+++ b/tools/cli/questions.ts
@@ -1,0 +1,132 @@
+import { Gateway } from '@ar.io/sdk';
+import { QuestionCollection } from 'inquirer';
+
+export default {
+  gatewaySettings: (
+    address?: string,
+    gateway?: Gateway,
+  ): QuestionCollection => {
+    const questionList: QuestionCollection = [
+      {
+        name: 'label',
+        type: 'input',
+        message: 'Enter your a friendly name for your gateway > ',
+        default: gateway ? gateway.settings.label : '',
+        validate: (value: string) =>
+          value.length > 0 ? true : 'Please Enter Valid Name',
+      },
+      {
+        name: 'fqdn',
+        type: 'input',
+        message: 'Enter your domain for this gateway > ',
+        default: gateway ? gateway.settings.fqdn : '',
+        validate: (value: string) => {
+          const regexDomainValidation: RegExp = new RegExp(
+            '^(?!-)[A-Za-z0-9-]+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,6}$',
+          );
+          return regexDomainValidation.test(value)
+            ? true
+            : 'Please Enter Valid Domain';
+        },
+      },
+      !gateway
+        ? {
+            name: 'qty',
+            type: 'number',
+            message:
+              'Enter the amount of tokens you want to stake against your gateway - min 10,000 IO > ',
+            default: 10000,
+            validate: (value: number) =>
+              value >= 10000 ? true : 'Please Enter Valid Amount',
+          }
+        : undefined,
+      {
+        name: 'port',
+        type: 'number',
+        message: 'Enter port used for this gateway > ',
+        default: gateway ? gateway.settings.port : 443,
+        validate: (value: number) => {
+          return value >= 0 && value <= 65535
+            ? true
+            : 'Please Enter Valid Port Number';
+        },
+      },
+      {
+        name: 'protocol',
+        type: 'list',
+        message: 'Enter protocol used for this gateway > ',
+        default: gateway ? gateway.settings.protocol : 'https',
+        choices: ['https'],
+      },
+      {
+        name: 'properties',
+        type: 'input',
+        message: 'Enter gateway properties (use default if not sure) > ',
+        default: gateway
+          ? gateway.settings.properties
+          : 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',
+        validate: (value: string) =>
+          value.length === 43 ? true : 'Please Enter Valid Properties',
+      },
+      {
+        name: 'note',
+        type: 'input',
+        message: 'Enter short note to further describe this gateway > ',
+        default: gateway
+          ? gateway.settings.note
+          : `Owned and operated by ${address}`,
+      },
+      {
+        name: 'observerWallet',
+        type: 'input',
+        default: gateway ? gateway.observerWallet : address,
+        message: 'Enter the observer wallet public address > ',
+      },
+      {
+        name: 'allowDelegatedStaking',
+        type: 'confirm',
+        default: gateway ? gateway.settings.allowDelegatedStaking : true,
+        message: 'Enable or disable delegated staking? > ',
+      },
+      {
+        name: 'delegateRewardShareRatio',
+        type: 'number',
+        message:
+          'Enter the percent of gateway and observer rewards given to delegates > ',
+        default: gateway ? gateway.settings.delegateRewardShareRatio : 10,
+        validate: (value: number) =>
+          value >= 0 && value <= 100 ? true : 'Please Enter Valid Percentage',
+      },
+      {
+        name: 'minDelegatedStake',
+        type: 'number',
+        message:
+          'Enter the minimum stake in IO a delegate must use for this for this gateway > ',
+        default: gateway ? gateway.settings.minDelegatedStake : 100,
+        validate: (value: number) =>
+          value > 0 ? true : 'Please Enter Valid Amount',
+      },
+    ].filter((question) => !!question);
+    return questionList;
+  },
+  delegateStake: (): QuestionCollection => {
+    const questionList: QuestionCollection = [
+      {
+        name: 'target',
+        type: 'input',
+        message: 'Enter the target gateway you want to delegate to > ',
+        validate: (value: string) =>
+          value.length === 43 ? true : 'Please Enter Valid Gateway Address',
+      },
+      {
+        name: 'qty',
+        type: 'number',
+        message: 'Enter Stake Quantity (in IO) > ',
+        default: 100,
+        validate: (value: number) =>
+          value > 0 ? true : 'Please Enter Valid Amount',
+      },
+    ];
+    return questionList;
+  },
+};

--- a/tools/cli/update-gateway-settings.ts
+++ b/tools/cli/update-gateway-settings.ts
@@ -37,9 +37,7 @@ import questions from './questions';
   );
 
   // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/update-gateway-settings.ts
+++ b/tools/cli/update-gateway-settings.ts
@@ -4,6 +4,7 @@ import inquirer from 'inquirer';
 
 import { IOState } from '../../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -35,9 +36,6 @@ import questions from './questions';
   const gatewayDetails = await inquirer.prompt(
     questions.gatewaySettings(walletAddress, existingGatewayDetails),
   );
-
-  // gate the contract txId
-  const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/cli/update-gateway-settings.ts
+++ b/tools/cli/update-gateway-settings.ts
@@ -1,0 +1,110 @@
+import { Gateway } from '@ar.io/sdk';
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import inquirer from 'inquirer';
+
+import { IOState } from '../../src/types';
+import {
+  arweave,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  networkContract,
+  warp,
+} from '../utilities';
+import questions from './questions';
+
+(async () => {
+  // simple setup script
+  initialize();
+
+  // Get the key file used for the distribution
+  const wallet: JWKInterface = loadWallet();
+
+  const walletAddress = await arweave.wallets.jwkToAddress(wallet);
+
+  const existingGatewayDetails: Gateway | undefined =
+    await networkContract.getGateway({
+      address: walletAddress,
+    });
+
+  if (!existingGatewayDetails) {
+    console.error('Gateway not found with address:', walletAddress);
+    return;
+  }
+
+  const gatewayDetails = await inquirer.prompt(
+    questions.gatewaySettings(walletAddress, existingGatewayDetails),
+  );
+
+  // gate the contract txId
+  const arnsContractTxId =
+    process.env.ARNS_CONTRACT_TX_ID ??
+    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
+  // get contract manifest
+  const { evaluationOptions = {} } = await getContractManifest({
+    contractTxId: arnsContractTxId,
+  });
+
+  // Connect the ArNS Registry Contract
+  const contract = await warp
+    .contract<IOState>(arnsContractTxId)
+    .connect(wallet)
+    .setEvaluationOptions(evaluationOptions)
+    .syncState(`https://api.arns.app/v1/contract/${arnsContractTxId}`, {
+      validity: true,
+    });
+
+  const confirm = await inquirer.prompt({
+    name: 'confirm',
+    type: 'confirm',
+    message: `CONFIRM UPDATED GATEWAY DETAILS? ${JSON.stringify(
+      gatewayDetails,
+    )} >`,
+  });
+
+  if (confirm.confirm) {
+    const payload = {
+      function: 'updateGatewaySettings',
+      ...(gatewayDetails.observerWallet
+        ? { observerWallet: gatewayDetails.observerWallet }
+        : {}),
+      ...(gatewayDetails.allowDelegatedStaking
+        ? { allowDelegatedStaking: gatewayDetails.allowDelegatedStaking }
+        : {}),
+      ...(gatewayDetails.delegateRewardShareRatio
+        ? {
+            delegateRewardShareRatio: gatewayDetails.delegateRewardShareRatio,
+          }
+        : {}),
+      ...(gatewayDetails.minDelegatedStake
+        ? { minDelegatedStake: gatewayDetails.minDelegatedStake }
+        : {}),
+      ...(gatewayDetails.note ? { note: gatewayDetails.note } : {}),
+      ...(gatewayDetails.properties
+        ? { properties: gatewayDetails.properties }
+        : {}),
+      ...(gatewayDetails.protocol ? { protocol: gatewayDetails.protocol } : {}),
+      ...(gatewayDetails.port ? { port: gatewayDetails.port } : {}),
+      ...(gatewayDetails.fqdn ? { fqdn: gatewayDetails.fqdn } : {}),
+      ...(gatewayDetails.label ? { label: gatewayDetails.label } : {}),
+      // note: removing qty from the payload as it's not a valid field for updateGatewaySettings
+    };
+    const dryWrite = await contract.dryWrite(payload);
+
+    if (dryWrite.type === 'error' || dryWrite.errorMessage) {
+      console.error('Failed to update gateway:', dryWrite.errorMessage);
+      return;
+    }
+
+    console.log('Submitting transaction to update gateway...');
+
+    const txId = await contract.writeInteraction(payload, {
+      disableBundling: true,
+    });
+    // eslint-disable-next-line
+    console.log(
+      `Successfully submitted request to update gateway. TxId: ${txId?.originalTxId}`,
+    );
+  }
+})();

--- a/tools/decrease-delegate-stake.ts
+++ b/tools/decrease-delegate-stake.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -27,11 +28,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/decrease-operator-stake.ts
+++ b/tools/decrease-operator-stake.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -22,11 +23,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/delegate-stake.ts
+++ b/tools/delegate-stake.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -26,11 +27,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/evolve-contract.ts
+++ b/tools/evolve-contract.ts
@@ -5,6 +5,7 @@ import { LoggerFactory } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -24,9 +25,6 @@ import {
   const wallet: JWKInterface = loadWallet();
 
   // load state of contract
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   const { evaluationOptions = {} } = await getContractManifest({
     contractTxId: arnsContractTxId,

--- a/tools/evolve-state.ts
+++ b/tools/evolve-state.ts
@@ -28,13 +28,13 @@ import { getContractManifest, initialize, loadWallet, warp } from './utilities';
       validity: true,
     });
 
-  const writeInteraction = await contract.writeInteraction(
+  const writeInteraction = await contract.dryWrite(
     {
       function: 'evolveState',
     },
-    {
-      disableBundling: true,
-    },
+    // {
+    //   disableBundling: true,
+    // },
   );
   console.log(JSON.stringify(writeInteraction, null, 2));
 })();

--- a/tools/evolve-state.ts
+++ b/tools/evolve-state.ts
@@ -1,15 +1,16 @@
 import { IOState } from '../src/types';
-import { getContractManifest, initialize, loadWallet, warp } from './utilities';
+import {
+  arnsContractTxId,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from './utilities';
 
 /* eslint-disable no-console */
 (async () => {
   // simple setup script
   initialize();
-
-  // load state of contract
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // load local wallet
   const wallet = loadWallet();

--- a/tools/evolve-state.ts
+++ b/tools/evolve-state.ts
@@ -28,13 +28,13 @@ import { getContractManifest, initialize, loadWallet, warp } from './utilities';
       validity: true,
     });
 
-  const writeInteraction = await contract.dryWrite(
+  const writeInteraction = await contract.writeInteraction(
     {
       function: 'evolveState',
     },
-    // {
-    //   disableBundling: true,
-    // },
+    {
+      disableBundling: true,
+    },
   );
   console.log(JSON.stringify(writeInteraction, null, 2));
 })();

--- a/tools/join-network.ts
+++ b/tools/join-network.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -57,11 +58,6 @@ import {
   // The minimum stake a delegate must use for this for this gateway.  Must be greater than the contracts minimum delegated stake
   // The default is 100
   // const minDelegatedStake: number = 200;
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/leave-network.ts
+++ b/tools/leave-network.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -21,11 +22,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/tick.ts
+++ b/tools/tick.ts
@@ -1,7 +1,13 @@
 import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
-import { getContractManifest, initialize, loadWallet, warp } from './utilities';
+import {
+  arnsContractTxId,
+  getContractManifest,
+  initialize,
+  loadWallet,
+  warp,
+} from './utilities';
 
 /* eslint-disable no-console */
 (async () => {
@@ -10,11 +16,6 @@ import { getContractManifest, initialize, loadWallet, warp } from './utilities';
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // get contract manifest
   const { evaluationOptions = {} } = await getContractManifest({

--- a/tools/transfer-tokens.ts
+++ b/tools/transfer-tokens.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -24,11 +25,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   const walletAddress = await arweave.wallets.jwkToAddress(wallet);
 

--- a/tools/update-gateway-settings.ts
+++ b/tools/update-gateway-settings.ts
@@ -2,6 +2,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 
 import { IOState } from '../src/types';
 import {
+  arnsContractTxId,
   arweave,
   getContractManifest,
   initialize,
@@ -50,11 +51,6 @@ import {
 
   // Get the key file used for the distribution
   const wallet: JWKInterface = loadWallet();
-
-  // gate the contract txId
-  const arnsContractTxId =
-    process.env.ARNS_CONTRACT_TX_ID ??
-    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // wallet address
   const walletAddress = await arweave.wallets.getAddress(wallet);

--- a/tools/utilities.ts
+++ b/tools/utilities.ts
@@ -1,3 +1,4 @@
+import { ArIO } from '@ar.io/sdk';
 import Arweave from 'arweave';
 import { Tag } from 'arweave/node/lib/transaction';
 import { config } from 'dotenv';
@@ -45,6 +46,12 @@ export function isipV4Address(ipV4Address: string): boolean {
     ipV4Address,
   );
 }
+
+export const networkContract = new ArIO({
+  contractTxId:
+    process.env.ARNS_CONTRACT_TX_ID ||
+    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U',
+});
 
 export const arweave = new Arweave({
   host: 'ar-io.dev',

--- a/tools/utilities.ts
+++ b/tools/utilities.ts
@@ -14,6 +14,9 @@ import { DeployPlugin } from 'warp-contracts-plugin-deploy';
 
 import { keyfile } from './constants';
 
+// gate the contract txId
+export const arnsContractTxId = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
 // intended to be run before any scripts
 export const initialize = (): void => {
   // load environment variables

--- a/tools/utilities.ts
+++ b/tools/utilities.ts
@@ -38,7 +38,8 @@ export const loadWallet = (): JWKInterface => {
 
 export function isArweaveAddress(address: string): boolean {
   const trimmedAddress = address.toString().trim();
-  return !/[a-z0-9_-]{43}/i.test(trimmedAddress);
+  const ARWEAVE_TX_REGEX = new RegExp('^[a-zA-Z0-9-_s+]{43}$');
+  return ARWEAVE_TX_REGEX.test(trimmedAddress);
 }
 
 export function isipV4Address(ipV4Address: string): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,6 +183,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ar-io/arns-pilot@workspace:."
   dependencies:
+    "@ar.io/sdk": alpha
     "@commitlint/config-conventional": ^17.7.0
     "@trivago/prettier-plugin-sort-imports": ^4.0.0
     "@types/jest": ^27.4.0
@@ -199,6 +200,7 @@ __metadata:
     eslint-plugin-jest-formatting: ^3.1.0
     eslint-plugin-prettier: ^3.3.1
     husky: ^8.0.3
+    inquirer: 8.0.0
     jest: ^27.4.3
     jest-junit: ^16.0.0
     lint-staged: ^14.0.1
@@ -213,6 +215,19 @@ __metadata:
     warp-contracts-plugin-deploy: ^1.0.1
   languageName: unknown
   linkType: soft
+
+"@ar.io/sdk@npm:alpha":
+  version: 1.0.0-alpha.8
+  resolution: "@ar.io/sdk@npm:1.0.0-alpha.8"
+  dependencies:
+    arweave: ^1.14.4
+    axios: 1.4.0
+    setimmediate: ^1.0.5
+    warp-contracts: ^1.4.38
+    winston: ^3.11.0
+  checksum: 3cd5644aa542f21b9665e0e796c92210fabe5a119a3c3a3c38641554e64e35cf629044a7fd1b275bf2bc31a434fca253c3607481819d072d6097f673c813f015
+  languageName: node
+  linkType: hard
 
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13":
   version: 7.22.13
@@ -617,6 +632,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: aa209963e0c3218e80a4a20553ba8c0fbb6fa13140540b4e5f97923790be06801fc90172c1114fc8b7e888b3d012b67298cde6b9e81521361becfaee400c662f
+  languageName: node
+  linkType: hard
+
 "@commitlint/cli@npm:^18.2.0":
   version: 18.2.0
   resolution: "@commitlint/cli@npm:18.2.0"
@@ -818,6 +840,17 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: 1.1.x
+    enabled: 2.0.x
+    kuler: ^2.0.0
+  checksum: 4879600c55c8315a0fb85fbb19057bad1adc08f0a080a8cb4e2b63f723c379bfc4283b68123a2b078d367b327dd8df12fcb27464efe791addc0a48b9df6d79a1
   languageName: node
   linkType: hard
 
@@ -2544,6 +2577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 519b6a1b30d4571965c9706ad5400a200b94e4050feca3e7856e3ea7ac00ec9903e32e9a10e2762d0f7e472d5d03e5f4b29c16c0bd8c1f77c8876c683b2231f1
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.2
   resolution: "@types/yargs-parser@npm:21.0.2"
@@ -3454,6 +3494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.3":
+  version: 3.2.5
+  resolution: "async@npm:3.2.5"
+  checksum: 5ec77f1312301dee02d62140a6b1f7ee0edd2a0f983b6fd2b0849b969f245225b990b47b8243e7b9ad16451a53e7f68e753700385b706198ced888beedba3af4
+  languageName: node
+  linkType: hard
+
 "async@npm:^3.2.4":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
@@ -3496,6 +3543,17 @@ __metadata:
     follow-redirects: ^1.14.9
     form-data: ^4.0.0
   checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.4.0":
+  version: 1.4.0
+  resolution: "axios@npm:1.4.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
   languageName: node
   linkType: hard
 
@@ -4279,7 +4337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -4304,10 +4362,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -4317,6 +4385,16 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.3
+    color-string: ^1.6.0
+  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
   languageName: node
   linkType: hard
 
@@ -4331,6 +4409,16 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 0c016fea2b91b733eb9f4bcdb580018f52c0bc0979443dad930e5037a968237ac53d9beb98e218d2e9235834f8eebce7f8e080422d6194e957454255bde71d3d
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: ^3.1.3
+    text-hex: 1.0.x
+  checksum: bb3934ef3c417e961e6d03d7ca60ea6e175947029bfadfcdb65109b01881a1c0ecf9c2b0b59abcd0ee4a0d7c1eae93beed01b0e65848936472270a0b341ebce8
   languageName: node
   linkType: hard
 
@@ -5052,6 +5140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 9d256d89f4e8a46ff988c6a79b22fa814b4ffd82826c4fdacd9b42e9b9465709d3b748866d0ab4d442dfc6002d81de7f7b384146ccd1681f6a7f868d2acca063
+  languageName: node
+  linkType: hard
+
 "encodeurl@npm:^1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
@@ -5718,6 +5813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: f94e2fb3acf5a7754165d04549460d3ae6c34830394d20c552197e3e000035d69732d74af04b9bed3283bf29fe2a9ebdcc0085e640b0be3cc3658b9726265e31
+  languageName: node
+  linkType: hard
+
 "figlet@npm:^1.5.2":
   version: 1.7.0
   resolution: "figlet@npm:1.7.0"
@@ -5792,6 +5894,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: e357144f48cfc9a7f52a82bbc6c23df7c8de639fce049cac41d41d62cabb740cdb9f14eddc6485e29c933104455bdd7a69bb14a9012cef9cd4fa252a4d0cf293
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.9":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
@@ -5799,6 +5908,16 @@ __metadata:
     debug:
       optional: true
   checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.0":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 
@@ -6567,6 +6686,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:8.0.0":
+  version: 8.0.0
+  resolution: "inquirer@npm:8.0.0"
+  dependencies:
+    ansi-escapes: ^4.2.1
+    chalk: ^4.1.0
+    cli-cursor: ^3.1.0
+    cli-width: ^3.0.0
+    external-editor: ^3.0.3
+    figures: ^3.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    run-async: ^2.4.0
+    rxjs: ^6.6.6
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+    through: ^2.3.6
+  checksum: 289a485752922998118668ae1c15001bd5ff1cb61e02d101da78c47dd9c9f4d46d2fcbcc9ebcae22dcdb820323636021508c723550394043dfde0e4f213596ec
+  languageName: node
+  linkType: hard
+
 "inquirer@npm:^7.0.0":
   version: 7.3.3
   resolution: "inquirer@npm:7.3.3"
@@ -6639,6 +6779,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
   languageName: node
   linkType: hard
 
@@ -7807,6 +7954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 9e10b5a1659f9ed8761d38df3c35effabffbd19fc6107324095238e4ef0ff044392cae9ac64a1c2dda26e532426485342226b93806bd97504b174b0dcf04ed81
+  languageName: node
+  linkType: hard
+
 "lazystream@npm:^1.0.0":
   version: 1.0.1
   resolution: "lazystream@npm:1.0.1"
@@ -8080,6 +8234,20 @@ __metadata:
     strip-ansi: ^7.0.1
     wrap-ansi: ^8.0.1
   checksum: 2c6b47dcce6f9233df6d232a37d9834cb3657a0749ef6398f1706118de74c55f158587d4128c225297ea66803f35c5ac3db4f3f617046d817233c45eedc32ef1
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.3.2, logform@npm:^2.4.0":
+  version: 2.6.0
+  resolution: "logform@npm:2.6.0"
+  dependencies:
+    "@colors/colors": 1.6.0
+    "@types/triple-beam": ^1.3.2
+    fecha: ^4.2.0
+    ms: ^2.1.1
+    safe-stable-stringify: ^2.3.1
+    triple-beam: ^1.3.0
+  checksum: b9ea74bb75e55379ad0eb3e4d65ae6e8d02bc45b431c218162878bf663997ab9258a73104c2b30e09dd2db288bb83c8bf8748e46689d75f5e7e34cf69378d6df
   languageName: node
   linkType: hard
 
@@ -8615,7 +8783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0":
+"ms@npm:^2.0.0, ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -9005,6 +9173,15 @@ __metadata:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: 1.x.x
+  checksum: fd008d7e992bdec1c67f53a2f9b46381ee12a9b8c309f88b21f0223546003fb47e8ad7c1fd5843751920a8d276c63bd4b45670ef80c61fb3e07dbccc962b5c7d
   languageName: node
   linkType: hard
 
@@ -9444,6 +9621,13 @@ __metadata:
     kleur: ^3.0.3
     sisteransi: ^1.0.5
   checksum: d8fd1fe63820be2412c13bfc5d0a01909acc1f0367e32396962e737cb2fc52d004f3302475d5ce7d18a1e8a79985f93ff04ee03007d091029c3f9104bffc007d
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 
@@ -9923,7 +10107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.0":
+"rxjs@npm:^6.6.0, rxjs@npm:^6.6.6":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -9959,6 +10143,13 @@ __metadata:
   version: 2.4.1
   resolution: "safe-stable-stringify@npm:2.4.1"
   checksum: d8e505c462031301040605a4836ca25b52a1744eff01b0939b4d43136638fb8e88e0cec3d3ab6ab8e26f501086e6ba6bf34b228f57bf2ac56cb8d4061355d723
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.4.3
+  resolution: "safe-stable-stringify@npm:2.4.3"
+  checksum: 3aeb64449706ee1f5ad2459fc99648b131d48e7a1fbb608d7c628020177512dc9d94108a5cb61bbc953985d313d0afea6566d243237743e02870490afef04b43
   languageName: node
   linkType: hard
 
@@ -10057,7 +10248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setimmediate@npm:^1.0.4":
+"setimmediate@npm:^1.0.4, setimmediate@npm:^1.0.5":
   version: 1.0.5
   resolution: "setimmediate@npm:1.0.5"
   checksum: c9a6f2c5b51a2dabdc0247db9c46460152ffc62ee139f3157440bd48e7c59425093f42719ac1d7931f054f153e2d26cf37dfeb8da17a794a58198a2705e527fd
@@ -10137,6 +10328,15 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
+  languageName: node
+  linkType: hard
+
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
   languageName: node
   linkType: hard
 
@@ -10370,6 +10570,13 @@ __metadata:
   dependencies:
     minipass: ^3.1.1
   checksum: bc447f5af814fa9713aa201ec2522208ae0f4d8f3bda7a1f445a797c7b929a02720436ff7c478fb5edc4045adb02b1b88d2341b436a80798734e2494f1067b36
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
   languageName: node
   linkType: hard
 
@@ -10715,6 +10922,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 1138f68adc97bf4381a302a24e2352f04992b7b1316c5003767e9b0d3367ffd0dc73d65001ea02b07cd0ecc2a9d186de0cf02f3c2d880b8a522d4ccb9342244a
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -10860,6 +11074,13 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 2e881a3e8e076b6f2b85b9ec9dd4a900d3f5016e6d21183ed98e78f9abcc0149e7d54d79a3f432b23afde46b0885bdcdcbff789f39bc75de796316961ec07f61
   languageName: node
   linkType: hard
 
@@ -11432,6 +11653,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"warp-contracts@npm:^1.4.38":
+  version: 1.4.38
+  resolution: "warp-contracts@npm:1.4.38"
+  dependencies:
+    archiver: ^5.3.0
+    arweave: 1.14.4
+    async-mutex: ^0.4.0
+    bignumber.js: 9.1.1
+    events: 3.3.0
+    fast-copy: ^3.0.0
+    level: ^8.0.0
+    memory-level: ^1.0.0
+    safe-stable-stringify: 2.4.1
+    stream-buffers: ^3.0.2
+    unzipit: ^1.4.0
+    warp-arbundles: ^1.0.4
+    warp-isomorphic: ^1.0.7
+    warp-wasm-metering: 1.0.1
+  checksum: ff167710d483e1e125396e745e8234d2816ff5d12081369b110325143aa6dc386bc2e7b7fc296a0860de1dd5994baed53957ce27fd14b1dc139bf5c05a503060
+  languageName: node
+  linkType: hard
+
 "warp-isomorphic@npm:1.0.0":
   version: 1.0.0
   resolution: "warp-isomorphic@npm:1.0.0"
@@ -11604,6 +11847,36 @@ __metadata:
   dependencies:
     string-width: ^1.0.2 || 2 || 3 || 4
   checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "winston-transport@npm:4.7.0"
+  dependencies:
+    logform: ^2.3.2
+    readable-stream: ^3.6.0
+    triple-beam: ^1.3.0
+  checksum: ce074b5c76a99bee5236cf2b4d30fadfaf1e551d566f654f1eba303dc5b5f77169c21545ff5c5e4fdad9f8e815fc6d91b989f1db34161ecca6e860e62fd3a862
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.11.0":
+  version: 3.12.0
+  resolution: "winston@npm:3.12.0"
+  dependencies:
+    "@colors/colors": ^1.6.0
+    "@dabh/diagnostics": ^2.0.2
+    async: ^3.2.3
+    is-stream: ^2.0.0
+    logform: ^2.4.0
+    one-time: ^1.0.0
+    readable-stream: ^3.4.0
+    safe-stable-stringify: ^2.3.1
+    stack-trace: 0.0.x
+    triple-beam: ^1.3.0
+    winston-transport: ^4.7.0
+  checksum: 7549e90d471312f3678c86fc51c86da05717be0390ecc0dc1a312a57f4ab3eb22e4fae1829291a05334376db8caa5f118d1de019d8c67e5f031ed70678363703
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds some CLI tooling for gateway operators.

Example:
```shell
❯ yarn update-gateway-settings
? Enter your a friendly name for your gateway >  Test Gateway
? Enter your domain for this gateway >  permanence-testing.org
? Enter port used for this gateway >  443
? Enter protocol used for this gateway >  https
? Enter gateway properties (use default if not sure) >  raJgvbFU-YAnku-WsupIdbTsqqGLQiYpGzoqk9SCVgY
? Enter short note to further describe this gateway >  Test Gateway operated by PDS for the AR.IO ecosystem.
? Enter the observer wallet public address >  IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs
? Enable or disable delegated staking? >  Yes
? Enter the percent of gateway and observer rewards given to delegates >  30
? Enter the minimum stake in IO a delegate must use for this for this gateway >  100000000
? CONFIRM UPDATED GATEWAY DETAILS? {"label":"Test Gateway","fqdn":"permanence-testing.org","port":443,"protocol":"https","properties":"raJgvbFU-YAnku-WsupIdbTsqqGLQiYpGzoqk9SCVgY","note":"Test Gateway operated by PDS for the AR.IO ecosys
tem.","observerWallet":"IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs","allowDelegatedStaking":true,"delegateRewardShareRatio":30,"minDelegatedStake":100000000} > Yes
```

Inspired by PR's from @enzifiri and @onekill0503